### PR TITLE
fix: build correctness, shell allowlist hardening, and 0.15.0 release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,131 @@
-# Discord Configuration
-DISCORD_BOT_TOKEN=your_discord_bot_token_here
+# RustyNail environment variables
+#
+# Every value below has a sensible default unless marked REQUIRED. Anything set
+# here is overridden by an explicit value in CONFIG_FILE (see config.yaml.example).
+# Full reference: docs/configuration.md
 
-# Anthropic Configuration
-ANTHROPIC_API_KEY=your_anthropic_api_key_here
+# ── Core ──────────────────────────────────────────────────────────────────────
+ANTHROPIC_API_KEY=your_anthropic_api_key_here   # REQUIRED (unless LLM_PROVIDER is stub/ollama/bedrock)
+# CONFIG_FILE=config.yaml
+# LOG_LEVEL=info                                # trace|debug|info|warn|error
+# RUST_LOG=rustynail=info                       # overrides LOG_LEVEL for tracing filters
 
-# Optional: LLM Configuration
+# ── Agents / LLM ──────────────────────────────────────────────────────────────
+# LLM_PROVIDER=anthropic          # anthropic|openai|ollama|gemini|bedrock|litellm|openai-compat|stub
 # LLM_MODEL=claude-3-5-sonnet-20241022
+# ANTHROPIC_API_BASE=https://api.anthropic.com  # override for proxies / mock servers
+# AWS_REGION=us-east-1                          # bedrock provider only
+# AGENTS_PLANNING_ENABLED=false
+# AGENTS_PLANNING_MAX_STEPS=5
+# AGENTS_RETRY_ENABLED=true
+# AGENTS_RETRY_MAX_ATTEMPTS=3
+# AGENTS_RETRY_BASE_DELAY_MS=500
+# AGENT_RETRY_JITTER_ENABLED=true
 
-# Optional: Gateway Configuration
+# ── Gateway ───────────────────────────────────────────────────────────────────
 # GATEWAY_HTTP_PORT=8080
 # GATEWAY_WEBSOCKET_PORT=18789
-# LOG_LEVEL=info
+# GATEWAY_API_TOKEN=                            # set to require `Authorization: Bearer <token>`
+# GATEWAY_MAX_BODY_BYTES=1048576
+# GATEWAY_REQUEST_TIMEOUT_SECONDS=30
+# GATEWAY_SHUTDOWN_TIMEOUT_SECONDS=30
+# GATEWAY_ALLOWED_WS_ORIGINS=                   # comma-separated; empty = allow all
+# GATEWAY_CHUNKING_ENABLED=true                 # split replies to per-platform limits
+# GATEWAY_FORMATTING_ENABLED=true               # channel-aware markdown formatting
+# GATEWAY_DEDUP_ENABLED=true
+# GATEWAY_DEDUP_WINDOW_SIZE=100
+# GATEWAY_AUTO_ROUTE_ATTACHMENTS=false          # prefix PDF/image attachments into the prompt
+
+# ── Rate limiting ─────────────────────────────────────────────────────────────
+# RATE_LIMIT_ENABLED=false
+# RATE_LIMIT_MESSAGES=20
+# RATE_LIMIT_WINDOW_SECONDS=60
+
+# ── Memory ────────────────────────────────────────────────────────────────────
+# MEMORY_BACKEND=inmemory         # inmemory|redis|sqlite|postgres|vector
+# REDIS_URL=redis://localhost:6379
+# REDIS_TTL_SECONDS=86400
+# SQLITE_PATH=~/.rustynail/memory.db
+# DATABASE_URL=postgres://user:pass@localhost/rustynail
+# VECTOR_STORE=
+# VECTOR_STORE_URL=
+# VECTOR_DECAY_HALF_LIFE_SECONDS=3600
+# EMBEDDING_PROVIDER=
+# EMBEDDING_MODEL=
+
+# ── Conversation summarization ─────────────────────────────────────────────────
+# SUMMARIZATION_ENABLED=false
+# SUMMARIZATION_MODEL=claude-3-5-haiku-20241022
+# SUMMARIZATION_TRIGGER_AT=40                   # message count threshold
+# SUMMARIZATION_TRIGGER_TOKEN_BUDGET=0          # 0 = disabled
+# SUMMARIZATION_KEEP_RECENT=10
+
+# ── Channels: Discord ─────────────────────────────────────────────────────────
+# DISCORD_BOT_TOKEN=                            # absent = Discord disabled
+
+# ── Channels: WhatsApp (Meta Cloud API) ───────────────────────────────────────
+# WHATSAPP_PHONE_NUMBER_ID=
+# WHATSAPP_ACCESS_TOKEN=
+# WHATSAPP_VERIFY_TOKEN=
+
+# ── Channels: Telegram ────────────────────────────────────────────────────────
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_MODE=webhook                         # webhook|longpoll
+# TELEGRAM_WEBHOOK_SECRET=
+
+# ── Channels: Slack ───────────────────────────────────────────────────────────
+# SLACK_BOT_TOKEN=
+# SLACK_SIGNING_SECRET=
+# SLACK_MODE=webhook                            # webhook|socket
+# SLACK_APP_TOKEN=                              # xapp-... required for socket mode
+
+# ── Channels: SMS (Twilio) ────────────────────────────────────────────────────
+# TWILIO_ACCOUNT_SID=
+# TWILIO_AUTH_TOKEN=
+# TWILIO_FROM_NUMBER=
+
+# ── Channels: Microsoft Teams ─────────────────────────────────────────────────
+# TEAMS_APP_ID=
+# TEAMS_APP_PASSWORD=
+# TEAMS_HMAC_SECRET=                            # empty = skip HMAC validation
+
+# ── Channels: Email (IMAP + SMTP) ─────────────────────────────────────────────
+# EMAIL_IMAP_HOST=
+# EMAIL_IMAP_PORT=993
+# EMAIL_SMTP_HOST=
+# EMAIL_SMTP_PORT=587
+# EMAIL_USERNAME=
+# EMAIL_PASSWORD=
+# EMAIL_FROM_ADDRESS=
+# EMAIL_INBOX=INBOX
+
+# ── Channels: Webchat ─────────────────────────────────────────────────────────
+# WEBCHAT_ENABLED=false
+# WEBCHAT_ALLOWED_ORIGINS=
+# WEBCHAT_WELCOME_MESSAGE=
+
+# ── Channels: Test channel (dev/test only — no credentials) ───────────────────
+# TEST_CHANNEL=false                            # enables POST /test/send + GET /test/responses
+
+# ── Tools ─────────────────────────────────────────────────────────────────────
+# TOOLS_ENABLED=false
+# TOOLS_MAX_STEPS=5
+# TOOLS_FILESYSTEM_ROOT=                        # sandbox root; unset = filesystem tool off
+# TAVILY_API_KEY=                               # unset = web search tool off
+# TOOLS_PDF_ENABLED=false
+# TOOLS_IMAGE_ENABLED=false
+# TOOLS_SHELL_ENABLED=false
+# TOOLS_SHELL_REQUIRE_APPROVAL=true             # keep true outside trusted environments
+# TOOLS_SHELL_ALLOWED_COMMANDS=                 # comma-separated; token-wise match, disables shell syntax
+
+# ── Skills ────────────────────────────────────────────────────────────────────
+# SKILLS_ENABLED=false
+# SKILLS_PATHS=./skills
+# SKILLS_MAX_ACTIVE=5
+
+# ── Observability ─────────────────────────────────────────────────────────────
+# OTEL_EXPORTER_OTLP_ENDPOINT=                  # e.g. http://localhost:4317; unset = tracing off
+# OTEL_SERVICE_NAME=rustynail
+# DASHBOARD_AUTH_PASSWORD=                      # enables basic auth on /dashboard
+# AUDIT_ENABLED=false
+# AUDIT_PATH=                                   # empty = stderr; otherwise NDJSON file path

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,14 @@ jobs:
         with:
           path: rustynail
 
+      # Pinned to a release tag rather than the default branch: agenkit is a
+      # path dependency, so Cargo cannot constrain its version and an upstream
+      # push would otherwise change what CI builds without a commit here.
       - name: Checkout agenkit (sibling)
         uses: actions/checkout@v4
         with:
           repository: scttfrdmn/agenkit
+          ref: v0.87.0
           path: agenkit
 
       - name: Install Rust toolchain

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,10 +23,13 @@ jobs:
         with:
           path: rustynail
 
+      # Keep this ref in sync with ci.yml — the released image must be built
+      # against the same agenkit revision CI validated.
       - name: Checkout agenkit (sibling)
         uses: actions/checkout@v4
         with:
           repository: scttfrdmn/agenkit
+          ref: v0.87.0
           path: agenkit
 
       - name: Log in to GitHub Container Registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-08-03
+
+Includes the documentation work originally logged under `[0.14.0]`, which was
+never tagged or released. See the note under that heading.
+
+### Security
+- The shell tool allowlist no longer prefix-matches the raw command string. `src/tools/shell.rs` checked `command.starts_with(prefix)` and then passed the whole string to `sh -c`, so an allowlist entry of `git` also permitted `git status; rm -rf ~` — the allowlist read as a boundary but did not bound execution. Entries are now tokenized and matched element-wise against the parsed argv, and an allowlisted command is exec'd directly instead of through a shell.
+
+### Fixed
+- Test channel (`POST /test/send`) now injects messages into the gateway pipeline instead of returning a bare `200` with no side effect; replies are captured and retrievable from `GET /test/responses`. The zero-credential harness was previously non-functional end to end.
+- Gateway no longer constructs three separate `TestChannel` instances with independent capture buffers. It builds one channel and hands the HTTP layer a `CapturedMessages` handle to the same buffer.
+- Docker builds now succeed. The builder image was `rust:1.75`, below the MSRV of several locked dependencies (`aws-credential-types` 1.3.0 requires 1.94.1, `wide` 1.6.0 requires 1.89, `base64ct` 1.8.3 is edition 2024). Builder image and the new `rust-version` field are both pinned to 1.94.
+- `tests/harness/harness_test.rs` was never compiled because it lives outside `tests/` root and had no `[[test]]` target. It is now registered, serialized against the process-wide response buffer, and polls for responses rather than reading once.
+- CI is green again. Every run since v0.9.0 failed at `cargo fmt --check`, so `cargo clippy -- -D warnings` and `cargo test` never executed upstream. Formatting is applied across the tree and all clippy findings are resolved: `derivable_impls` (`AuditConfig`), `let_and_return` (`create_router`), three `manual_div_ceil` sites, `type_complexity` (new `RingBuffer` alias), `await_holding_lock` (harness lock is now `tokio::sync::Mutex`), and unused imports / dead code in the test helpers.
+
+### Added
+- `rust-version = "1.94"` in `Cargo.toml`, documenting the MSRV and keeping it in sync with the Dockerfile builder image.
+- `Dockerfile.dockerignore` — the build context is the parent directory (required for the agenkit path dependency), so an allowlist prevents sibling projects from being swept into the context.
+- `CapturedMessages` type alias and `TestChannel::captured_handle()` / `drain_captured()` in `src/channels/testchan.rs`.
+
+### Changed
+- **BREAKING (shell tool allowlist):** a non-empty `tools.shell.allowed_commands` now disables shell syntax. Commands containing `;`, `|`, `&`, `$`, `` ` ``, `>`, `<`, or a newline are rejected, and the command is exec'd directly rather than via `sh -c` — so pipes, redirection, substitution, and globbing are unavailable. Quotes still group arguments. Matching is token-wise, so `git` permits `git log` but no longer `gitleaks`, and `git status` permits only that subcommand. Clear the allowlist to opt back into full shell semantics. Only affects deployments that configured an allowlist; the default is empty.
+- Both CI workflows pin `ref: v0.87.0` when checking out agenkit instead of tracking the default branch. A path dependency carries no version constraint, so an upstream push previously changed what CI and release images built with no commit here.
+- `.env.example` refreshed from 13 lines (frozen at v0.1.0) to a complete, sectioned reference covering every environment variable read by `src/config/mod.rs`.
+- `README.md` prerequisites and badge updated to Rust 1.94+; added agenkit sibling-clone instructions, the pinned release tag, and directory layout.
+- `CLAUDE.md` documents the agenkit sibling-clone prerequisite, the pin-to-a-tag rule, the required directory layout, and the 1.94 minimum toolchain; the parity table now states that ✅ requires verification, not just shipped code.
+- `docs/configuration.md` documents how `shell.allowed_commands` is enforced, with a migration note for the behaviour change.
+
+### Removed
+- Dead `config: TeamsConfig` field from `TeamsChannel` (the only build warning); only the auth credentials are needed past construction.
+- Unused `make_test_config` helper from `tests/common/mod.rs` and the unreachable `AlwaysFailAgent` from `src/agents/manager.rs` (it could not be injected into `AgentManager`).
+
 ## [0.14.0] - 2026-03-18
+
+> Logged as released on 2026-03-18 but never tagged, and no image was published.
+> The Docker build could not have succeeded at this point — the builder image
+> was below the MSRV of the locked dependencies. Shipped as part of `0.15.0`.
 
 ### Added
 - `docs/configuration.md`: complete field-by-field configuration reference for all 11 top-level config sections (`gateway`, `channels`, `agents`, `memory`, `tools`, `skills`, `audit`, `cron`, `mcp`, `otel`, `dashboard`); includes env var table, YAML examples, and per-backend subsections
@@ -291,8 +327,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Structured logging with `tracing` and `tracing-subscriber`
 - README with architecture diagrams, quick start, and HTTP endpoint documentation
 
-[Unreleased]: https://github.com/scttfrdmn/rustynail/compare/v0.14.0...HEAD
-[0.14.0]: https://github.com/scttfrdmn/rustynail/compare/v0.13.0...v0.14.0
+[Unreleased]: https://github.com/scttfrdmn/rustynail/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/scttfrdmn/rustynail/compare/v0.13.0...v0.15.0
+[0.14.0]: https://github.com/scttfrdmn/rustynail/compare/v0.13.0...v0.15.0
 [0.13.0]: https://github.com/scttfrdmn/rustynail/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/scttfrdmn/rustynail/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/scttfrdmn/rustynail/compare/v0.10.0...v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-03-18
+
+### Added
+- `docs/configuration.md`: complete field-by-field configuration reference for all 11 top-level config sections (`gateway`, `channels`, `agents`, `memory`, `tools`, `skills`, `audit`, `cron`, `mcp`, `otel`, `dashboard`); includes env var table, YAML examples, and per-backend subsections
+- `docs/deployment.md`: operator runbook covering Docker pre-built image, Docker Compose (with agenkit build-context note), Kubernetes via Helm, full environment variable cheat sheet, health check + K8s probe YAML, Prometheus/Grafana integration, SIGHUP hot-reload procedure, and production checklist
+- `docs/channels.md`: per-channel setup guide for all 12 channels (Discord, WhatsApp, Telegram webhook+longpoll, Slack webhook+socket, SMS/Twilio, Teams, Email, Webchat, Generic Webhook, Test Channel); each section includes prerequisites, credential steps, minimal config snippet, webhook URLs, and caveats
+- `docs/cli.md`: man-page style reference for all 7 CLI subcommands (`start`, `status`, `version`, `config check`, `config validate`, `completions`, `mcp serve`); includes option tables, exit codes, and example output
+- `docs/api.md`: complete HTTP API reference for all route groups (health/probes, dashboard, channel webhooks, webchat, admin, cron, user preferences, OpenAI-compat, test channel); includes request/response schemas and curl examples
+- `docs/architecture.md`: architecture deep-dive with updated ASCII diagram (12 channels, 5 memory backends, tool registry, MCP); 8-stage message pipeline documentation; channel adapter pattern; agent manager internals; memory backend comparison; hot-reload mechanics; full observability coverage; source map table
+- `docs/troubleshooting.md`: troubleshooting guide covering startup failures, per-channel issues, no-response debugging steps, memory backend errors, performance tuning, and useful debug commands
+
+### Changed
+- `README.md`: complete overhaul from v0.4.0 baseline; updated badges to v0.13.0 beta; rewrote Features section to reflect current reality (12 channels, 7 LLM providers, 5 memory backends, full tool registry); updated Quick Start, Channels, Deployment, HTTP API, CLI, and Architecture sections; replaced stale Roadmap section with Sister Projects table; fixed version references from "0.1.0 Alpha" to "0.13.0 Beta"
+
 ## [0.13.0] - 2026-03-18
 
 ### Added
@@ -277,7 +291,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Structured logging with `tracing` and `tracing-subscriber`
 - README with architecture diagrams, quick start, and HTTP endpoint documentation
 
-[Unreleased]: https://github.com/scttfrdmn/rustynail/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/rustynail/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/scttfrdmn/rustynail/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/scttfrdmn/rustynail/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/scttfrdmn/rustynail/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/scttfrdmn/rustynail/compare/v0.10.0...v0.11.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,7 @@ Update this table at the start of each milestone planning session.
 | v0.11.0 | Message Quality & Resilience — chunking, deduplication, channel formatting, attachment routing, retry jitter, provider fallback | Closed (released 2026-03-18) |
 | v0.12.0 | Streaming & Memory Intelligence — Teams HMAC, vector decay, token compaction, WS streaming, OpenAI SSE | Closed (released 2026-03-18) |
 | v0.13.0 | Integration Testing & Operational Maturity — rate limiter/agent/HotConfig/admin API/Teams/pipeline tests, config validate, admin audit logging | Closed (released 2026-03-18) |
+| v0.14.0 | Deployment & User Documentation — README overhaul, docs/ reference directory (configuration, deployment, channels, CLI, API, architecture, troubleshooting) | Closed (released 2026-03-18) |
 | v1.0.0 | Production Ready — full hardening, docs, dashboard v2 | Open |
 
 ## Architecture Overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,13 +3,38 @@
 ## Project Overview
 
 - **Name**: RustyNail
-- **Version**: 0.12.0
+- **Version**: 0.15.0
 - **GitHub**: https://github.com/scttfrdmn/rustynail
 - **License**: Apache 2.0
 - **Description**: High-performance personal AI assistant built with Rust and Agenkit-Rust. Connects to messaging platforms (Discord, WhatsApp, Telegram, Slack) where users interact via chat.
 - **Sister Project**: [BuckTooth](https://github.com/scttfrdmn/bucktooth) (Go implementation)
 
 ## Build & Run Commands
+
+**Prerequisite:** agenkit is a local path dependency (`../agenkit/agenkit-rust`)
+and must be cloned as a sibling directory, or `cargo build` fails immediately:
+
+```bash
+git clone https://github.com/scttfrdmn/agenkit.git   # in the parent of rustynail/
+cd agenkit && git checkout v0.87.0                   # pin to the tested release
+```
+
+**Pin to a release tag, not `main`.** A path dependency carries no version
+constraint, so Cargo will happily build against whatever is checked out. Both
+CI workflows pin `ref: v0.87.0`; when bumping agenkit, update `ci.yml`,
+`docker.yml`, and this file together so local, CI, and release builds agree.
+
+Required layout — both CI workflows check out this same structure:
+
+```
+parent/
+├── agenkit/agenkit-rust/
+└── rustynail/
+```
+
+Minimum Rust toolchain is **1.94** (`rust-version` in Cargo.toml), set by the AWS
+SDK crates that agenkit's Bedrock adapter pulls in. Keep it in sync with the
+Dockerfile builder image.
 
 ```bash
 # Build (debug)
@@ -125,7 +150,7 @@ Before drafting a milestone plan:
 2. List each gap with the source project (`BuckTooth`, `OpenClaw`, or `Both`) and a short description.
 3. Assign gaps to the milestone or a future one, and create GitHub issues for each.
 
-### Parity status (as of v0.12.0)
+### Parity status (as of v0.15.0)
 
 | Feature area | BuckTooth | OpenClaw | Notes |
 |---|---|---|---|
@@ -166,7 +191,7 @@ Before drafting a milestone plan:
 | Docker / distroless image | ✅ | ✅ | |
 | CI/CD (GitHub Actions) | ✅ | ✅ | |
 | Criterion benchmarks | ✅ | — | BuckTooth has none |
-| Zero-credential test harness | ✅ | — | BuckTooth has none |
+| Zero-credential test harness | ✅ | — | BuckTooth has none. Verified working end-to-end as of 2026-08-03 |
 | Shell completion | ✅ | ✅ | |
 | PDF analysis tool | ✅ | — | |
 | Image analysis tool | ✅ | — | |
@@ -188,12 +213,17 @@ Before drafting a milestone plan:
 
 Update this table at the start of each milestone planning session.
 
+A ✅ means the feature exists **and has been verified to work**. Before marking a
+row ✅, exercise it — two rows in this table previously claimed parity for code
+that was shipped but non-functional (the test harness returned an empty buffer,
+and Docker builds failed on an MSRV too low for the locked dependencies).
+
 ## Milestones
 
 | Milestone | Description | Status |
 |-----------|-------------|--------|
 | v0.1.0 | Foundation — core types, Discord, Agenkit, HTTP | Closed (released 2026-02-01) |
-| v0.2.0 | Tools & Multi-Channel — tool registry, WhatsApp | Open |
+| v0.2.0 | Tools & Multi-Channel — tool registry, WhatsApp | Closed (released 2026-03-17) |
 | v0.3.0 | Platform Expansion — Telegram, Slack, OpenTelemetry | Closed (released 2026-03-17) |
 | v0.4.0 | Production Infrastructure — Docker, CI/CD, web dashboard | Closed (released 2026-03-17) |
 | v0.4.5 | Config flexibility + integration test suite | Closed (released 2026-03-18) |
@@ -206,8 +236,10 @@ Update this table at the start of each milestone planning session.
 | v0.11.0 | Message Quality & Resilience — chunking, deduplication, channel formatting, attachment routing, retry jitter, provider fallback | Closed (released 2026-03-18) |
 | v0.12.0 | Streaming & Memory Intelligence — Teams HMAC, vector decay, token compaction, WS streaming, OpenAI SSE | Closed (released 2026-03-18) |
 | v0.13.0 | Integration Testing & Operational Maturity — rate limiter/agent/HotConfig/admin API/Teams/pipeline tests, config validate, admin audit logging | Closed (released 2026-03-18) |
-| v0.14.0 | Deployment & User Documentation — README overhaul, docs/ reference directory (configuration, deployment, channels, CLI, API, architecture, troubleshooting) | Closed (released 2026-03-18) |
+| v0.14.0 | Deployment & User Documentation — README overhaul, docs/ reference directory (configuration, deployment, channels, CLI, API, architecture, troubleshooting) | Never tagged; shipped as part of v0.15.0 (#94) |
+| v0.15.0 | Build & Supply Chain Correctness — shell allowlist hardening, working Docker build (MSRV 1.94), functional test harness, green CI, agenkit pinned to v0.87.0 | Closed (released 2026-08-03) |
 | v1.0.0 | Production Ready — full hardening, docs, dashboard v2 | Open |
+| v1.1.0 | Post-1.0 Channel Expansion — Matrix, Signal/IRC/LINE/Viber/WeChat, social DMs | Open |
 
 ## Architecture Overview
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-bedrockruntime",
- "axum 0.7.9",
+ "axum 0.8.9",
  "chrono",
  "crossbeam",
  "futures",
@@ -27,34 +27,30 @@ dependencies = [
  "lru",
  "moka",
  "once_cell",
- "opentelemetry 0.23.0",
- "opentelemetry-jaeger",
- "opentelemetry-otlp",
- "opentelemetry-prometheus",
+ "opentelemetry 0.32.0",
+ "opentelemetry-otlp 0.32.0",
  "opentelemetry-stdout",
- "opentelemetry-zipkin",
- "opentelemetry_sdk 0.23.0",
+ "opentelemetry_sdk 0.32.1",
  "parking_lot",
- "prometheus",
- "prost",
- "rand 0.8.5",
+ "prost 0.14.4",
+ "rand 0.9.2",
  "rayon",
- "redis",
+ "redis 1.2.4",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_yaml",
  "statrs",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.21.0",
- "tonic",
- "tower 0.4.13",
- "tower-http 0.5.2",
+ "tokio-tungstenite 0.29.0",
+ "tonic 0.14.6",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
  "tracing",
- "tracing-opentelemetry 0.23.0",
+ "tracing-opentelemetry 0.33.0",
  "tracing-subscriber",
  "uuid",
 ]
@@ -178,12 +174,18 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
 name = "arraydeque"
@@ -294,7 +296,7 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http 0.62.6",
- "aws-smithy-json",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -313,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.11"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -347,23 +349,24 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.18"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "959dab27ce613e6c9658eb3621064d0e2027e5f2acb65bc526a43577facea557"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "bytes-utils",
  "fastrand",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -372,26 +375,29 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.122.0"
+version = "1.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c14680affe00d9bda89ddeb7a41004ac130165aef6678078da58df22dec3ff1"
+checksum = "8dffe4bd3da45048fa0d30b50febaedf093e93a25d832cc21f2845a6e0c72616"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.6",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "hyper 0.14.32",
+ "http 1.4.0",
+ "http-body-util",
  "regex-lite",
  "tracing",
 ]
@@ -406,8 +412,8 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.62.6",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-json 0.61.9",
+ "aws-smithy-observability 0.2.4",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -429,8 +435,8 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.62.6",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-json 0.61.9",
+ "aws-smithy-observability 0.2.4",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -452,8 +458,8 @@ dependencies = [
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http 0.62.6",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-json 0.61.9",
+ "aws-smithy-observability 0.2.4",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -468,32 +474,32 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.7"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.11.0",
  "time",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.11"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52eec3db979d18cb807fc1070961cc51d87d069abe9ab57917769687368a8c6c"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -502,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.18"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b9c7354a3b13c66f60fe4616d6d1969c9fd36b1b5333a5dfb3ee716b33c588"
+checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -517,7 +523,6 @@ version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
- "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -535,10 +540,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.3"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630e67f2a31094ffa51b210ae030855cb8f3b7ee1329bdd8d085aaf61e8b97fc"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -556,25 +562,19 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.9"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fb0abf49ff0cab20fd31ac1215ed7ce0ea92286ba09e2854b42ba5cabe7525"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
  "h2 0.4.13",
- "http 0.2.12",
  "http 1.4.0",
- "http-body 0.4.6",
- "hyper 0.14.32",
  "hyper 1.8.1",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
  "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -594,10 +594,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
 name = "aws-smithy-observability"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0a46543fbc94621080b3cf553eb4cbbdc41dd9780a30c4756400f0139440a1d"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -614,15 +634,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3df87c14f0127a0d77eb261c3bc45d5b4833e2a1f63583ebfb728e4852134ee"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.63.3",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-http-client",
- "aws-smithy-observability",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -639,11 +660,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49952c52f7eebb72ce2a754d3866cc0f87b97d2a46146b79f80f3a93fb2b3716"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -655,10 +677,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.3"
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3a26048eeab0ddeba4b4f9d51654c79af8c3b32357dc5f336cee85ab331c33"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -691,13 +735,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.11"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -718,7 +763,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -748,7 +793,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -762,6 +807,39 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-tungstenite 0.24.0",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -804,6 +882,34 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]
@@ -865,6 +971,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bufstream"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,9 +1005,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytes-utils"
@@ -1044,6 +1159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1228,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1293,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1303,6 +1439,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1468,15 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1351,7 +1505,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1383,10 +1537,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1577,9 +1743,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1855,20 +2021,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
@@ -1912,7 +2078,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1921,7 +2087,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2026,6 +2201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,21 +2258,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
@@ -2115,6 +2284,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2149,9 +2331,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2326,12 +2510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2565,55 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "jobserver"
@@ -2548,11 +2775,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2597,6 +2824,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,7 +2846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2739,13 +2972,12 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.6"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
 dependencies = [
  "approx",
  "matrixmultiply",
- "nalgebra-macros",
  "num-complex",
  "num-rational",
  "num-traits",
@@ -2753,17 +2985,6 @@ dependencies = [
  "rand_distr",
  "simba",
  "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -2829,6 +3050,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2885,6 +3116,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2897,16 +3129,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -2988,21 +3210,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
@@ -3016,32 +3223,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.12.0"
+name = "opentelemetry"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ba633e55c5ea6f431875ba55e71664f2fa5d3a90bd34ec9302eecc41c865dd"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
- "async-trait",
- "bytes",
- "http 0.2.12",
- "opentelemetry 0.23.0",
- "reqwest 0.11.27",
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
-name = "opentelemetry-jaeger"
-version = "0.22.0"
+name = "opentelemetry-http"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501b471b67b746d9a07d4c29f8be00f952d1a2eca356922ede0098cbaddff19f"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
- "futures-core",
- "futures-util",
- "opentelemetry 0.23.0",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.23.0",
- "thrift",
- "tokio",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry 0.32.0",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -3054,25 +3259,31 @@ dependencies = [
  "futures-core",
  "http 0.2.12",
  "opentelemetry 0.23.0",
- "opentelemetry-proto",
+ "opentelemetry-proto 0.6.0",
  "opentelemetry_sdk 0.23.0",
- "prost",
+ "prost 0.12.6",
  "thiserror 1.0.69",
  "tokio",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
-name = "opentelemetry-prometheus"
-version = "0.16.0"
+name = "opentelemetry-otlp"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1a24eafe47b693cb938f8505f240dc26c71db60df9aca376b4f857e9653ec7"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "once_cell",
- "opentelemetry 0.23.0",
- "opentelemetry_sdk 0.23.0",
- "prometheus",
- "protobuf",
+ "http 1.4.0",
+ "opentelemetry 0.32.0",
+ "opentelemetry-http",
+ "opentelemetry-proto 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prost 0.14.4",
+ "reqwest 0.13.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-types",
 ]
 
 [[package]]
@@ -3083,72 +3294,32 @@ checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
 dependencies = [
  "opentelemetry 0.23.0",
  "opentelemetry_sdk 0.23.0",
- "prost",
- "tonic",
+ "prost 0.12.6",
+ "tonic 0.11.0",
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.15.0"
+name = "opentelemetry-proto"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1869fb4bb9b35c5ba8a1e40c9b128a7b4c010d07091e864a29da19e4fe2ca4d7"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+ "tonic-prost",
+]
 
 [[package]]
 name = "opentelemetry-stdout"
-version = "0.4.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d080bf06af02b738feb2e6830cf72c30b76ca18b40f555cdf1b53e7b491bfe"
+checksum = "a1b1c6a247d79091f0062a5f4bd058589525cf987a8d4c169440d9c1be72f0ad"
 dependencies = [
- "async-trait",
  "chrono",
- "futures-util",
- "opentelemetry 0.23.0",
- "opentelemetry_sdk 0.23.0",
- "ordered-float 4.6.0",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opentelemetry-zipkin"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ef6ac37be83507328641e625d68cefd1d262f57222f3358705a07fd4afc432"
-dependencies = [
- "async-trait",
- "futures-core",
- "http 0.2.12",
- "once_cell",
- "opentelemetry 0.23.0",
- "opentelemetry-http",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.23.0",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "typed-builder",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "once_cell",
- "opentelemetry 0.22.0",
- "ordered-float 4.6.0",
- "percent-encoding",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
 ]
 
 [[package]]
@@ -3165,22 +3336,30 @@ dependencies = [
  "lazy_static",
  "once_cell",
  "opentelemetry 0.23.0",
- "ordered-float 4.6.0",
+ "ordered-float",
  "percent-encoding",
  "rand 0.8.5",
- "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
+name = "opentelemetry_sdk"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
- "num-traits",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3304,7 +3483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3583,7 +3762,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -3597,6 +3786,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -3641,6 +3852,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3792,22 +4004,41 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
 dependencies = [
- "arc-swap",
- "async-trait",
- "bytes",
  "combine",
- "futures",
+ "itoa",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.4.10",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae41a63fd0b8a5372f82b21e810e09a316f5dd7efd96bf08e678fb240fc1918"
+dependencies = [
+ "arc-swap",
+ "arcstr",
+ "async-lock",
+ "backon",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-channel",
  "futures-util",
  "itoa",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.4.10",
+ "socket2 0.6.2",
  "tokio",
- "tokio-retry",
  "tokio-util",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -3917,7 +4148,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -3943,6 +4174,48 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3977,8 +4250,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -4027,18 +4300,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
 ]
 
 [[package]]
@@ -4102,14 +4363,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-platform-verifier"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "ring",
- "untrusted",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4142,7 +4420,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustynail"
-version = "0.13.0"
+version = "0.15.0"
 dependencies = [
  "agenkit",
  "anyhow",
@@ -4158,7 +4436,7 @@ dependencies = [
  "dotenvy",
  "futures-util",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "imap",
  "jsonpath-rust",
  "lettre",
@@ -4166,10 +4444,10 @@ dependencies = [
  "mockito",
  "native-tls",
  "opentelemetry 0.23.0",
- "opentelemetry-otlp",
+ "opentelemetry-otlp 0.16.0",
  "opentelemetry_sdk 0.23.0",
  "prometheus",
- "redis",
+ "redis 0.24.0",
  "reqwest 0.11.27",
  "scraper",
  "serde",
@@ -4177,7 +4455,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "serenity",
- "sha2",
+ "sha2 0.10.9",
  "sqlx",
  "subtle",
  "tempfile",
@@ -4245,16 +4523,6 @@ dependencies = [
  "once_cell",
  "selectors",
  "tendril",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -4472,8 +4740,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4489,8 +4757,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4524,15 +4803,15 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "simba"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
 dependencies = [
  "approx",
  "num-complex",
@@ -4546,6 +4825,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -4678,7 +4973,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlformat",
  "thiserror 1.0.69",
@@ -4716,7 +5011,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -4739,7 +5034,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -4749,7 +5044,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -4760,7 +5055,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4788,7 +5083,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -4798,7 +5093,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4857,9 +5152,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f697a07e4606a0a25c044de247e583a330dbb1731d11bc7350b81f48ad567255"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
 dependencies = [
  "approx",
  "nalgebra",
@@ -5070,28 +5365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "log",
- "ordered-float 2.10.1",
- "threadpool",
-]
-
-[[package]]
 name = "time"
 version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5215,27 +5488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand 0.8.5",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5295,6 +5547,18 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -5366,16 +5630,67 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.12.6",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum 0.8.9",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.2",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types",
+ "tonic 0.14.6",
 ]
 
 [[package]]
@@ -5406,9 +5721,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5447,6 +5765,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5507,14 +5826,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.22.0",
- "opentelemetry_sdk 0.22.1",
+ "opentelemetry 0.23.0",
+ "opentelemetry_sdk 0.23.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -5525,14 +5844,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.24.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "once_cell",
- "opentelemetry 0.23.0",
- "opentelemetry_sdk 0.23.0",
+ "opentelemetry 0.32.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -5619,23 +5936,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-builder"
-version = "0.18.2"
+name = "tungstenite"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5646,9 +5959,9 @@ checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -5925,6 +6238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6033,6 +6355,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -6319,6 +6652,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yaml-rust2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "rustynail"
-version = "0.13.0"
+version = "0.15.0"
 edition = "2021"
+# Highest MSRV among locked dependencies — the AWS SDK crates (via agenkit's
+# Bedrock adapter) require 1.94.1. Keep in sync with Dockerfile's builder image.
+rust-version = "1.94"
 authors = ["Scott Friedman <scttfrdmn@users.noreply.github.com>"]
 description = "RustyNail - High-performance AI assistant built with Rust and Agenkit"
 license = "Apache-2.0"
@@ -111,3 +114,10 @@ path = "src/main.rs"
 [[bench]]
 name = "gateway_benchmarks"
 harness = false
+
+# Zero-credential harness tests. They require a live instance
+# (CONFIG_FILE=configs/harness.yaml cargo run) and self-skip unless
+# HARNESS_URL is set, so they are safe to run in the default `cargo test`.
+[[test]]
+name = "harness_test"
+path = "tests/harness/harness_test.rs"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@
 # Compose: docker-compose.yml sets context: .. and dockerfile: rustynail/Dockerfile
 
 # ── Stage 1: Builder ──────────────────────────────────────────────────────────
-FROM rust:1.82-slim-bookworm AS builder
+# Toolchain must satisfy the highest MSRV in Cargo.lock. The AWS SDK crates
+# pulled in via agenkit's Bedrock adapter require 1.94.1; base64ct 1.8.3 is
+# edition 2024 (1.85) and wide 1.6.0 needs 1.89. Keep this in sync with
+# `rust-version` in Cargo.toml.
+FROM rust:1.94-slim-bookworm AS builder
 
 # Install C toolchain and OpenSSL dev headers (required by reqwest / openssl-sys)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -1,0 +1,18 @@
+# Build context is the PARENT of rustynail/ (so the agenkit path dep resolves),
+# which means rustynail/.dockerignore is not consulted — Docker reads this file
+# instead because it sits beside the Dockerfile named in `-f`.
+#
+# Without it, a local `docker build ..` sweeps in every sibling project in the
+# parent directory (tens of GB). Allowlist only what the build needs.
+*
+
+!rustynail/
+!agenkit/
+
+# Re-exclude heavy or irrelevant subtrees from the two allowed dirs
+**/target/
+**/.git/
+**/node_modules/
+rustynail/diary/
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -2,357 +2,269 @@
 
 **"Rust Never Sleeps!"**
 
-RustyNail is a high-performance personal AI assistant built with Rust and Agenkit-Rust. It connects to messaging platforms (Discord, WhatsApp, Telegram, Slack) where users interact with it naturally through chat.
-
-[![Version](https://img.shields.io/badge/version-0.4.0-blue)](https://github.com/scttfrdmn/rustynail/releases/tag/v0.4.0)
+[![Version](https://img.shields.io/badge/version-0.13.0-blue)](https://github.com/scttfrdmn/rustynail/releases/tag/v0.13.0)
 [![Rust](https://img.shields.io/badge/rust-1.75%2B-orange)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green)](LICENSE)
-[![Status](https://img.shields.io/badge/status-alpha-yellow)](https://github.com/scttfrdmn/rustynail)
+[![Status](https://img.shields.io/badge/status-beta-yellow)](https://github.com/scttfrdmn/rustynail)
+[![CI](https://github.com/scttfrdmn/rustynail/actions/workflows/ci.yml/badge.svg)](https://github.com/scttfrdmn/rustynail/actions/workflows/ci.yml)
+
+RustyNail is a high-performance AI gateway built with Rust. It connects 12 messaging platforms to multiple LLM providers through a single statically-linked binary. Users interact naturally through their chat platform of choice; RustyNail handles routing, memory, tools, and response formatting.
+
+## What Is RustyNail?
+
+RustyNail is a single-binary Rust AI gateway that:
+
+- Routes messages from **12 channels** (Discord, WhatsApp, Telegram, Slack, SMS, Teams, Email, Webchat, and more) to an AI backend
+- Supports **7 LLM providers** (Anthropic, OpenAI, Ollama, Gemini, AWS Bedrock, LiteLLM, OpenAI-compat)
+- Maintains **per-user conversation memory** across 5 backends (in-memory, Redis, SQLite, Postgres, vector)
+- Runs a **tool registry** (calculator, web search, web fetch, filesystem, PDF/image analysis, shell, calendar)
+- Exposes an **Admin API**, **cron scheduler**, **agent skills**, and an **OpenAI-compatible `/v1/chat/completions`** endpoint
+- Ships as a **distroless Docker image** (~8 MB) with <30 MB RAM idle and <1 ms gateway overhead
+
+Sister project: [BuckTooth](https://github.com/scttfrdmn/bucktooth) (Go implementation). Reference implementation: [OpenClaw](https://github.com/scttfrdmn/openclaw).
 
 ## Features
 
-- **Multi-Channel Support**: Discord (Phase 1), WhatsApp, Telegram, Slack (coming soon)
-- **Conversational AI**: Powered by Claude via Agenkit-Rust
-- **Memory**: Maintains conversation context across channels
-- **Performance**: Built with Rust for maximum speed and safety
-- **Production-Ready**: Built-in observability, metrics, and health checks
-- **Single Binary**: Easy deployment with minimal dependencies
+### Channels (12)
+
+| Channel | Mode | Auth |
+|---------|------|------|
+| Discord | Gateway (serenity) | Bot token |
+| WhatsApp | Webhook (Meta Cloud API) | Phone number ID + access token |
+| Telegram | Webhook | Bot token + secret header |
+| Telegram | Long-poll | Bot token (no public URL) |
+| Slack | Events API webhook | Signing secret |
+| Slack | Socket Mode | App-level token (`xapp-`) |
+| SMS / Twilio | TwiML webhook | Account SID + auth token |
+| Microsoft Teams | Bot Framework webhook | App ID + password + optional HMAC |
+| Email | IMAP + SMTP | Host + credentials |
+| Webchat | WebSocket | Optional CORS origins |
+| Generic Webhook | HTTP POST | Optional HMAC-SHA256 |
+| Test Channel | HTTP inject/drain | None (dev/test only) |
+
+See [docs/channels.md](docs/channels.md) for per-channel setup instructions.
+
+### LLM Providers (7)
+
+`anthropic` · `openai` · `ollama` · `gemini` · `bedrock` · `litellm` · `openai-compat`
+
+Configurable retry with exponential backoff + jitter, and a provider fallback chain for capacity errors.
+
+### Memory Backends (5)
+
+`inmemory` · `redis` · `sqlite` · `postgres` · `vector` (temporal decay + half-life scoring)
+
+Automatic conversation summarization when history exceeds a message count or token budget threshold.
+
+### Tools
+
+calculator · web search (Tavily) · web fetch · filesystem · PDF analysis · image analysis · shell · calendar · formatter
+
+### Production Features
+
+- **MCP**: expose tools via `rustynail mcp serve` (stdio); consume external MCP servers
+- **Admin API**: clear user memory, reload skills, inspect channel health
+- **Cron scheduler**: fire synthetic messages on configurable intervals
+- **Agent skills**: inject SKILL.md context files into agent system prompts
+- **OpenAI-compatible endpoint**: `POST /v1/chat/completions` (non-streaming + SSE)
+- **Prometheus metrics** + **OpenTelemetry tracing** + **Grafana dashboard config**
+- **Web dashboard** with WebSocket live updates
+- **SIGHUP hot-reload**: update log level, API token, rate limits, audit config without restart
+- **Bearer token auth**, per-user rate limiting, request body limits, handler timeouts
+- **Structured NDJSON audit log**
 
 ## Quick Start
 
-### Prerequisites
-
-- Rust 1.75 or higher
-- Discord bot token (get from [Discord Developer Portal](https://discord.com/developers/applications))
-- Anthropic API key (get from [Anthropic Console](https://console.anthropic.com))
-
-### Installation
+**Prerequisites:** Rust 1.75+, an Anthropic API key (or other provider).
 
 ```bash
-# Clone the repository
+# 1. Clone and build
 git clone https://github.com/scttfrdmn/rustynail.git
 cd rustynail
-
-# Build
 cargo build --release
 
-# Or run directly
-cargo run
+# 2. Set the required environment variable
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# 3. Start (env-vars only — no channels except test channel)
+./target/release/rustynail
+
+# 4. Or start with a config file
+CONFIG_FILE=config.yaml ./target/release/rustynail
+
+# 5. Verify
+curl http://localhost:8080/health
+# {"status":"ok","version":"0.13.0"}
 ```
 
-### Configuration
-
-Create a `.env` file or export environment variables:
-
-```bash
-export DISCORD_BOT_TOKEN=your_discord_bot_token
-export ANTHROPIC_API_KEY=your_anthropic_api_key
-```
-
-Or create a configuration file:
+**Minimal `config.yaml`:**
 
 ```yaml
-# config.yaml
 gateway:
-  websocket_port: 18789
   http_port: 8080
+  websocket_port: 18789
   log_level: info
-
-channels:
-  discord:
-    enabled: true
-    auth:
-      token: ${DISCORD_BOT_TOKEN}
 
 agents:
   llm_provider: anthropic
   llm_model: claude-3-5-sonnet-20241022
   api_key: ${ANTHROPIC_API_KEY}
   max_history: 20
-  temperature: 0.7
 ```
 
-### Running
+See [docs/configuration.md](docs/configuration.md) for the complete configuration reference.
+
+## Channels
+
+See [docs/channels.md](docs/channels.md) for per-channel prerequisites, credential steps, config snippets, and webhook verification.
+
+## Deployment
 
 ```bash
-# Using environment variables
-./target/release/rustynail
+# Docker (pre-built)
+docker pull ghcr.io/scttfrdmn/rustynail:latest
+docker run --rm -e ANTHROPIC_API_KEY=... -p 8080:8080 ghcr.io/scttfrdmn/rustynail:latest
 
-# Using config file
-CONFIG_FILE=config.yaml ./target/release/rustynail
-
-# With custom log level
-RUST_LOG=debug cargo run
+# Docker Compose (build context must be the parent directory for agenkit)
+cd ..
+ANTHROPIC_API_KEY=... docker-compose -f rustynail/docker-compose.yml up
 ```
 
-## Usage
+See [docs/deployment.md](docs/deployment.md) for the Docker Compose setup, Helm/Kubernetes runbook, environment variable cheat sheet, Prometheus/Grafana integration, and production checklist.
 
-1. Invite your Discord bot to a server
-2. Start RustyNail
-3. Send a message to the bot in Discord
-4. The bot will respond using Claude AI with conversation memory
+## HTTP API
 
-## HTTP Endpoints
+| Group | Routes |
+|-------|--------|
+| Health & probes | `GET /health` `/ready` `/live` `/status` `/metrics` |
+| Dashboard | `GET /dashboard` `/dashboard/data` `GET /dashboard/ws` (WebSocket) |
+| Channel webhooks | `POST /webhooks/whatsapp` `/webhooks/telegram` `/webhooks/slack` `/webhooks/sms` `/webhooks/teams` `/webhooks/:name` |
+| Webchat | `GET /channels/webchat/ws` (WebSocket) `/channels/webchat/widget.js` |
+| Admin | `DELETE /admin/memory/:user_id` `POST /admin/skills/reload` `GET /admin/channels/health` |
+| Cron | `GET /cron/jobs` |
+| User preferences | `GET /users/:id/preferences` `POST /users/:id/preferences` |
+| OpenAI-compat | `POST /v1/chat/completions` |
+| Test channel | `POST /test/send` `GET /test/responses` |
 
-RustyNail provides comprehensive health and monitoring endpoints:
+See [docs/api.md](docs/api.md) for the complete HTTP API reference including request/response schemas.
 
-- **`GET /health`** - Basic health check (for load balancers)
-  ```json
-  {"status": "ok", "version": "0.1.0"}
-  ```
+## CLI
 
-- **`GET /status`** - Detailed system status
-  ```json
-  {
-    "status": "running",
-    "version": "0.1.0",
-    "channels": [...],
-    "active_users": 42
-  }
-  ```
-
-- **`GET /metrics`** - Operational metrics (Prometheus-compatible)
-  ```json
-  {
-    "active_users": 42,
-    "channels_count": 1,
-    "healthy_channels": 1
-  }
-  ```
-
-- **`GET /ready`** - Readiness probe (returns 503 if not ready)
-- **`GET /live`** - Liveness probe (for Kubernetes)
-- **`GET /dashboard`** - Web monitoring dashboard (HTML)
-- **`GET /dashboard/data`** - Dashboard JSON data endpoint
-
-### Dashboard
-
-The web dashboard provides real-time monitoring at `http://localhost:8080/dashboard`:
-
-- Message counters (in/out), active users, uptime, message rate
-- Channel health table with running status
-- Recent messages ring buffer (last 50)
-
-Optional basic auth — set `DASHBOARD_AUTH_PASSWORD` to require a password:
-
-```bash
-DASHBOARD_AUTH_PASSWORD=secret cargo run
-# Credentials: rustynail / <password>
+```
+rustynail start                     # Start the gateway (default)
+rustynail status [--port N]         # Query a running instance
+rustynail version                   # Print version and build info
+rustynail config check              # Load config and print summary
+rustynail config validate           # Preflight checks; exits 0/1
+rustynail completions <shell>       # Print shell completion script
+rustynail mcp serve                 # Expose tools as MCP server (stdio)
 ```
 
-### Testing Endpoints
-
-```bash
-# Test all endpoints
-./test-health.sh
-
-# Or individually
-curl http://localhost:8080/health
-curl http://localhost:8080/status
-curl http://localhost:8080/metrics
-```
+See [docs/cli.md](docs/cli.md) for the full CLI reference.
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│  RustyNail Gateway (Single Binary)                        │
-│  ┌─────────────────────────────────────────────────┐   │
-│  │ HTTP Server (Axum) - Port 8080                  │   │
-│  │ ├─ /health  - Health check                      │   │
-│  │ ├─ /status  - Detailed status                   │   │
-│  │ ├─ /metrics - Operational metrics               │   │
-│  │ ├─ /ready   - Readiness probe (K8s)             │   │
-│  │ └─ /live    - Liveness probe (K8s)              │   │
-│  └─────────────────────────────────────────────────┘   │
-│  ┌─────────────────────────────────────────────────┐   │
-│  │ Gateway Core                                     │   │
-│  │ - Channel Registry & Lifecycle                  │   │
-│  │ - Message Router & Event Bus                    │   │
-│  │ - Agent Manager (Per-User)                      │   │
-│  └─────────────────────────────────────────────────┘   │
-│           │                                             │
-│  ┌────────┴────────┬──────────┬──────────┐            │
-│  │ Discord Channel │ WhatsApp │ Telegram │ Slack...   │
-│  └────────┬────────┴──────────┴──────────┘            │
-│           │                                             │
-│  ┌────────▼────────────────────────────────────────┐  │
-│  │ Agent Manager (Per-User ConversationalAgents)   │  │
-│  │ - Anthropic Claude 3.5 Sonnet                   │  │
-│  │ - Agenkit-Rust Integration                      │  │
-│  └────────┬────────────────────────────────────────┘  │
-│           │                                             │
-│  ┌────────▼────────────────────────────────────────┐  │
-│  │ Memory Store (In-Memory)                         │  │
-│  └──────────────────────────────────────────────────┘  │
-└─────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────┐
+│  RustyNail Gateway (Single Binary)                                       │
+│                                                                          │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │  HTTP Server (Axum :8080)                                         │  │
+│  │  /health /ready /live /status /metrics  ← Health & observability  │  │
+│  │  /dashboard /dashboard/ws               ← Web dashboard (WS push) │  │
+│  │  /webhooks/*  /channels/webchat/ws      ← Inbound channel hooks   │  │
+│  │  /admin/*  /cron/*  /users/*            ← Admin & management      │  │
+│  │  /v1/chat/completions                   ← OpenAI-compat SSE       │  │
+│  └──────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │  Message Pipeline                                                  │  │
+│  │  Dedup → Audit → Rate limit → Attachment route →                  │  │
+│  │  Memory write → Summarize (async) → Agent (retry+fallback) →      │  │
+│  │  Format → Chunk → Channel send                                    │  │
+│  └──────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+│  ┌────────────┐  ┌──────────────────┐  ┌───────────────────────────┐  │
+│  │  Channels  │  │  Agent Manager   │  │  Memory Backends           │  │
+│  │  Discord   │  │  Per-user        │  │  inmemory / redis          │  │
+│  │  WhatsApp  │  │  Conversational  │  │  sqlite / postgres         │  │
+│  │  Telegram  │  │  Agents          │  │  vector (temporal decay)   │  │
+│  │  Slack     │  │  Multi-LLM       │  └───────────────────────────┘  │
+│  │  SMS       │  │  7 providers     │                                   │
+│  │  Teams     │  └──────────────────┘  ┌───────────────────────────┐  │
+│  │  Email     │                         │  Tool Registry             │  │
+│  │  Webchat   │  ┌──────────────────┐  │  calculator / web-search   │  │
+│  │  Webhook   │  │  MCP             │  │  web-fetch / filesystem    │  │
+│  │  + Test    │  │  Server (stdio)  │  │  pdf / image / shell       │  │
+│  └────────────┘  │  Client          │  │  calendar / formatter      │  │
+│                  └──────────────────┘  └───────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────┘
 ```
+
+See [docs/architecture.md](docs/architecture.md) for a deep-dive into the message pipeline, channel adapter pattern, memory backend internals, hot-reload mechanics, and observability coverage.
 
 ## Development
 
-### Project Structure
-
-```
-rustynail/
-├── src/
-│   ├── main.rs              # Application entry point
-│   ├── lib.rs               # Library root
-│   ├── types.rs             # Core types and enums
-│   ├── config/              # Configuration management
-│   ├── gateway/             # Gateway implementation
-│   ├── channels/            # Channel adapters (Discord, etc.)
-│   ├── memory/              # Memory management
-│   └── agents/              # Agent configurations
-├── diary/                   # Development diary (not in git)
-├── Cargo.toml               # Rust dependencies
-└── README.md                # This file
-```
-
-## Container Deployment
-
-The build context must be the **parent** directory of `rustynail/` because `agenkit` is a local
-path dependency at `../agenkit/agenkit-rust`.
-
-### Docker (manual)
-
 ```bash
-# Build from the parent directory
-docker buildx build -f rustynail/Dockerfile -t rustynail:latest ..
+cargo build           # Debug build
+cargo build --release # Release build
+cargo test            # Run all 138+ tests
+cargo test -- --nocapture  # With output
+cargo clippy          # Lint
+cargo fmt             # Format
 
-# Run
-docker run --rm \
-  -e DISCORD_BOT_TOKEN=... \
-  -e ANTHROPIC_API_KEY=... \
-  -p 8080:8080 \
-  rustynail:latest
+# Zero-credential integration tests (test channel)
+RUST_LOG=debug CONFIG_FILE=configs/harness.yaml cargo run
+curl -X POST http://localhost:8080/test/send \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id":"u1","content":"hello"}'
+curl http://localhost:8080/test/responses
 ```
 
-### docker-compose
-
-```bash
-# From the parent directory (one level above rustynail/)
-cd ..
-DISCORD_BOT_TOKEN=... ANTHROPIC_API_KEY=... docker-compose -f rustynail/docker-compose.yml up
-```
-
-A pre-built image is published to GitHub Container Registry on every version tag:
-
-```bash
-docker pull ghcr.io/scttfrdmn/rustynail:latest
-```
-
-### Development
-
-```bash
-# Debug build
-cargo build
-
-# Release build (optimized)
-cargo build --release
-
-# Build with all optimizations
-cargo build --release --features production
-```
-
-### Testing
-
-```bash
-# Run all tests
-cargo test
-
-# Run tests with output
-cargo test -- --nocapture
-
-# Run specific test
-cargo test test_name
-```
-
-## Roadmap
-
-### Phase 1: Foundation ✅ (95% Complete)
-- [x] Project setup
-- [x] Core types and traits
-- [x] Configuration system
-- [x] Memory store
-- [x] Discord channel
-- [x] Agenkit integration (Claude 3.5 Sonnet)
-- [x] Per-user conversation agents
-- [x] HTTP health & metrics endpoints
-- [ ] End-to-end testing
-
-### Phase 2: Tools & Multi-Channel
-- [ ] Tool registry
-- [ ] Calculator, Message, FileSystem tools
-- [ ] WhatsApp channel
-- [ ] Cross-channel messaging
-
-### Phase 3: Expansion
-- [ ] Telegram channel
-- [ ] Slack channel
-- [ ] Planning agent
-- [ ] Calendar & Web Search tools
-- [ ] OpenTelemetry tracing
-
-### Phase 4: Polish
-- [ ] Web dashboard
-- [ ] Enhanced CLI
-- [ ] Docker image
-- [ ] Kubernetes manifests
-- [ ] Migration tool from OpenClaw
+**Criterion benchmarks** are in `benches/gateway_benchmarks.rs` — run with `cargo bench`.
 
 ## Performance
 
-Expected performance characteristics:
-
-- **Binary Size**: ~5-10 MB (optimized release)
-- **Memory Usage**: ~20-30 MB base + 1 MB per agent
-- **CPU Usage**: <0.5% idle, <3% under load
-- **Latency**: <1ms overhead
+- **Binary size**: ~8 MB (distroless release)
+- **RAM idle**: <30 MB base + ~1 MB per active agent
+- **CPU idle**: <0.5%
+- **Gateway overhead**: <1 ms
 - **Throughput**: 10,000+ messages/second
 
-Compared to BuckTooth (Go):
-- **Binary Size**: ~50% smaller
-- **Memory**: ~40% less
-- **Performance**: Similar or better
-- **Safety**: Compile-time guarantees
+Compared to BuckTooth (Go): ~50% smaller binary, ~40% less memory, similar or better throughput with compile-time safety guarantees.
+
+Criterion benchmark suite: `benches/gateway_benchmarks.rs` (`bench_inmemory_store_add`, `bench_config_load`, `bench_message_stats_record`).
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or submit a pull request.
+Contributions are welcome. Please open an issue or submit a pull request.
+
+- All work tracked on [GitHub Issues](https://github.com/scttfrdmn/rustynail/issues)
+- Follow [Conventional Commits](https://www.conventionalcommits.org/)
+- Run `cargo fmt` and `cargo clippy` before submitting
+
+## Sister Projects
+
+| Project | Language | Repo |
+|---------|----------|------|
+| BuckTooth | Go | https://github.com/scttfrdmn/bucktooth |
+| OpenClaw | Reference | https://github.com/scttfrdmn/openclaw |
+| Agenkit | Rust SDK | https://github.com/scttfrdmn/agenkit |
 
 ## Versioning
 
-This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+Follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html). Pre-1.0 minor bumps (`0.X.0`) may include breaking changes.
 
-Current version: **0.1.0** (Alpha)
+Current version: **0.13.0 (Beta)**
 
-See [CHANGELOG.md](CHANGELOG.md) for a detailed history of changes.
+See [CHANGELOG.md](CHANGELOG.md) for the full history.
 
 ## License
 
 Copyright 2026 Scott Friedman
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-See [LICENSE](LICENSE) for the full license text.
-
-## Acknowledgments
-
-- Built with [Agenkit-Rust](https://github.com/scttfrdmn/agenkit)
-- Inspired by [OpenClaw](https://github.com/openclaw/openclaw)
-- Sister project: [BuckTooth](https://github.com/scttfrdmn/bucktooth) (Go implementation)
-- Powered by [Anthropic Claude](https://www.anthropic.com)
+Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full text.
 
 ## Why "RustyNail"?
 
-A rusty nail is strong, enduring, and gets the job done. Plus, Rust + Nail = RustyNail! 🦀🔨
+A rusty nail is strong, enduring, and gets the job done. Rust + Nail = RustyNail. 🦀🔨

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **"Rust Never Sleeps!"**
 
-[![Version](https://img.shields.io/badge/version-0.13.0-blue)](https://github.com/scttfrdmn/rustynail/releases/tag/v0.13.0)
-[![Rust](https://img.shields.io/badge/rust-1.75%2B-orange)](https://www.rust-lang.org/)
+[![Version](https://img.shields.io/badge/version-0.15.0-blue)](https://github.com/scttfrdmn/rustynail/releases/tag/v0.15.0)
+[![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green)](LICENSE)
 [![Status](https://img.shields.io/badge/status-beta-yellow)](https://github.com/scttfrdmn/rustynail)
 [![CI](https://github.com/scttfrdmn/rustynail/actions/workflows/ci.yml/badge.svg)](https://github.com/scttfrdmn/rustynail/actions/workflows/ci.yml)
@@ -75,26 +75,39 @@ calculator · web search (Tavily) · web fetch · filesystem · PDF analysis · 
 
 ## Quick Start
 
-**Prerequisites:** Rust 1.75+, an Anthropic API key (or other provider).
+**Prerequisites:** Rust 1.94+, an Anthropic API key (or other provider).
+
+RustyNail depends on [agenkit](https://github.com/scttfrdmn/agenkit) as a local
+path dependency at `../agenkit/agenkit-rust`, so it must be cloned as a sibling
+directory. Without it `cargo build` fails immediately.
 
 ```bash
-# 1. Clone and build
+# 1. Clone both repos side by side, pinning agenkit to the tested release
+git clone https://github.com/scttfrdmn/agenkit.git
+git -C agenkit checkout v0.87.0
 git clone https://github.com/scttfrdmn/rustynail.git
+
+# Layout must be:
+#   parent/
+#   ├── agenkit/agenkit-rust/
+#   └── rustynail/
+
+# 2. Build
 cd rustynail
 cargo build --release
 
-# 2. Set the required environment variable
+# 3. Set the required environment variable
 export ANTHROPIC_API_KEY=sk-ant-...
 
-# 3. Start (env-vars only — no channels except test channel)
+# 4. Start (env-vars only — no channels except test channel)
 ./target/release/rustynail
 
-# 4. Or start with a config file
+# 5. Or start with a config file
 CONFIG_FILE=config.yaml ./target/release/rustynail
 
-# 5. Verify
+# 6. Verify
 curl http://localhost:8080/health
-# {"status":"ok","version":"0.13.0"}
+# {"status":"ok","version":"0.15.0"}
 ```
 
 **Minimal `config.yaml`:**
@@ -255,7 +268,7 @@ Contributions are welcome. Please open an issue or submit a pull request.
 
 Follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html). Pre-1.0 minor bumps (`0.X.0`) may include breaking changes.
 
-Current version: **0.13.0 (Beta)**
+Current version: **0.15.0 (Beta)**
 
 See [CHANGELOG.md](CHANGELOG.md) for the full history.
 

--- a/deploy/helm/rustynail/Chart.yaml
+++ b/deploy/helm/rustynail/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rustynail
 description: RustyNail — High-performance AI assistant built with Rust and Agenkit
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.15.0
+appVersion: "0.15.0"
 keywords:
   - ai
   - assistant

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@ Basic health check for load balancers.
 
 **Response 200:**
 ```json
-{"status": "ok", "version": "0.13.0"}
+{"status": "ok", "version": "0.15.0"}
 ```
 
 ---
@@ -62,7 +62,7 @@ Detailed system status including channel health and active users.
 ```json
 {
   "status": "running",
-  "version": "0.13.0",
+  "version": "0.15.0",
   "uptime_seconds": 3600,
   "channels": [
     {"name": "discord-main", "status": "healthy", "detail": ""},
@@ -112,7 +112,7 @@ Dashboard JSON data endpoint.
 **Response 200:**
 ```json
 {
-  "version": "0.13.0",
+  "version": "0.15.0",
   "uptime_seconds": 3600,
   "messages_in": 1234,
   "messages_out": 1230,

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,451 @@
+# HTTP API Reference
+
+RustyNail exposes a single HTTP server on `gateway.http_port` (default 8080). This document covers all routes.
+
+## Authentication
+
+When `GATEWAY_API_TOKEN` is set, all routes except `/live` and `/ready` require:
+
+```
+Authorization: Bearer <token>
+```
+
+Requests without a valid token return `401 Unauthorized`. The token is checked with constant-time comparison (no timing oracle). Tokens can be updated at runtime via SIGHUP without restart.
+
+**Auth-exempt routes:** `/live`, `/ready`
+
+---
+
+## Health & Probes
+
+### `GET /health`
+
+Basic health check for load balancers.
+
+**Auth required:** no (if token is set, auth is required — use `/live` for probe-exempt check)
+
+**Response 200:**
+```json
+{"status": "ok", "version": "0.13.0"}
+```
+
+---
+
+### `GET /ready`
+
+Kubernetes readiness probe. Returns 503 until the gateway has fully started.
+
+**Auth required:** never (always exempt)
+
+**Response 200:** `{"status": "ready"}`
+**Response 503:** `{"status": "not_ready"}`
+
+---
+
+### `GET /live`
+
+Kubernetes liveness probe. Returns 200 while the process is running.
+
+**Auth required:** never (always exempt)
+
+**Response 200:** `{"status": "alive"}`
+
+---
+
+### `GET /status`
+
+Detailed system status including channel health and active users.
+
+**Auth required:** yes (when token configured)
+
+**Response 200:**
+```json
+{
+  "status": "running",
+  "version": "0.13.0",
+  "uptime_seconds": 3600,
+  "channels": [
+    {"name": "discord-main", "status": "healthy", "detail": ""},
+    {"name": "slack-main",   "status": "degraded", "detail": "reconnecting"}
+  ],
+  "active_users": 42
+}
+```
+
+---
+
+### `GET /metrics`
+
+Prometheus metrics endpoint.
+
+**Auth required:** yes (when token configured)
+**Content-Type:** `text/plain; version=0.0.4`
+
+```
+# HELP rustynail_messages_in_total Total inbound messages
+# TYPE rustynail_messages_in_total counter
+rustynail_messages_in_total 1234
+...
+```
+
+Key metrics: `rustynail_messages_in_total`, `rustynail_messages_out_total`, `rustynail_active_users`, `rustynail_healthy_channels`, `rustynail_message_duration_seconds`, `rustynail_tokens_in_total`, `rustynail_tokens_out_total`, `rustynail_auth_failures_total`, `rustynail_rate_limit_hits_total`, `rustynail_llm_errors_total`, `rustynail_llm_retries_total`.
+
+---
+
+## Dashboard
+
+### `GET /dashboard`
+
+Web monitoring dashboard (embedded HTML/CSS/JS, no CDN dependency).
+
+**Auth required:** yes if `DASHBOARD_AUTH_PASSWORD` set (HTTP Basic Auth, username `rustynail`)
+**Response:** HTML page with real-time stats, channel health table, and recent messages ring buffer.
+
+---
+
+### `GET /dashboard/data`
+
+Dashboard JSON data endpoint.
+
+**Auth required:** same as `/dashboard`
+
+**Response 200:**
+```json
+{
+  "version": "0.13.0",
+  "uptime_seconds": 3600,
+  "messages_in": 1234,
+  "messages_out": 1230,
+  "tokens_in": 45000,
+  "tokens_out": 38000,
+  "active_users": 42,
+  "channels": [...],
+  "recent_messages": [
+    {"ts": "2026-03-18T12:00:00Z", "user_id": "u1", "direction": "in", "content": "hello"}
+  ]
+}
+```
+
+---
+
+### `GET /dashboard/ws`
+
+WebSocket endpoint for live dashboard push updates.
+
+**Auth required:** same as `/dashboard`
+**Upgrade:** WebSocket
+
+**Server-sent frame types:**
+
+```json
+// Stats update (every 5 seconds)
+{"type": "stats_update", "data": { ...same as /dashboard/data... }}
+
+// Message event (on each inbound/outbound message)
+{"type": "message_event", "data": {"ts": "...", "user_id": "...", "direction": "in", "content": "..."}}
+```
+
+Origin restriction: if `gateway.allowed_ws_origins` is set, upgrade requests from unlisted origins return `403 Forbidden`.
+
+---
+
+## Channel Webhooks
+
+### `GET /webhooks/whatsapp`
+
+Meta webhook verification (challenge-response).
+
+**Query params:** `hub.mode=subscribe`, `hub.verify_token=<token>`, `hub.challenge=<value>`
+**Response 200:** echoes `hub.challenge` if verify token matches
+**Response 403:** verify token mismatch
+
+---
+
+### `POST /webhooks/whatsapp`
+
+Inbound WhatsApp messages.
+
+**Body:** Meta Cloud API webhook JSON
+**Response 200:** `"ok"`
+
+---
+
+### `POST /webhooks/telegram`
+
+Inbound Telegram updates.
+
+**Headers:** `X-Telegram-Bot-Api-Secret-Token: <secret>` (when `webhook_secret` is configured)
+**Body:** Telegram Update JSON
+**Response 200:** `"ok"`
+
+---
+
+### `POST /webhooks/slack`
+
+Inbound Slack events (Events API + `url_verification` challenge).
+
+**Headers:** `X-Slack-Signature`, `X-Slack-Request-Timestamp` (HMAC-SHA256 verification)
+**Body:** Slack event JSON
+**Response 200:** `""` (empty) or `{"challenge": "..."}` for url_verification
+
+---
+
+### `POST /webhooks/sms`
+
+Inbound Twilio SMS messages (TwiML webhook).
+
+**Body:** URL-encoded form (`Body`, `From`, `To`)
+**Response 200:** Empty TwiML `<Response/>`
+
+---
+
+### `POST /channels/teams/messages`
+
+Inbound Microsoft Teams Bot Framework activities.
+
+**Headers:** `Authorization: HMAC <hex>` (when `hmac_secret` is configured)
+**Body:** Bot Framework Activity JSON
+**Response 200:** `"ok"`
+**Response 401:** HMAC validation failed
+
+---
+
+### `POST /webhooks/:name`
+
+Generic inbound webhook. `:name` must match a configured `channels.webhook.endpoints[].path`.
+
+**Headers:** `X-Hub-Signature-256: sha256=<hex>` (when endpoint `secret` is configured)
+**Body:** Any JSON or text
+**Response 200:** `"ok"`
+**Response 401:** HMAC validation failed
+**Response 404:** No endpoint matches `:name`
+
+---
+
+## Webchat
+
+### `GET /channels/webchat/ws`
+
+WebSocket chat session for the webchat widget.
+
+**Query params:** `session_id=<uuid>` (required)
+**Upgrade:** WebSocket
+**Origin restriction:** `channels.webchat.allowed_origins` and/or `gateway.allowed_ws_origins`
+
+**Client → server frames:** plain text message content
+
+**Server → client frame types:**
+```json
+// Token streaming (arrives in ~5-byte chunks)
+{"type": "token", "content": "Hello"}
+// Stream complete
+{"type": "done"}
+// Error
+{"type": "error", "message": "..."}
+```
+
+---
+
+### `GET /channels/webchat/widget.js`
+
+Serves the self-contained chat widget JavaScript (~3KB, no dependencies).
+
+**Response:** `application/javascript`
+
+Embed with:
+```html
+<script src="https://rustynail.example.com/channels/webchat/widget.js"></script>
+```
+
+---
+
+## Admin API
+
+All admin routes require bearer auth when `GATEWAY_API_TOKEN` is set.
+
+### `DELETE /admin/memory/:user_id`
+
+Clear a user's conversation history from the memory backend.
+
+**Path param:** `user_id` — the user whose history to delete
+**Response 200:** `{"cleared": true, "user_id": "..."}`
+
+```bash
+curl -X DELETE http://localhost:8080/admin/memory/user123 \
+  -H 'Authorization: Bearer <token>'
+```
+
+---
+
+### `POST /admin/skills/reload`
+
+Hot-reload skills from disk without restarting the server.
+
+**Body:** none
+**Response 200:**
+```json
+{"skills_loaded": 4}
+```
+
+```bash
+curl -X POST http://localhost:8080/admin/skills/reload \
+  -H 'Authorization: Bearer <token>'
+```
+
+---
+
+### `GET /admin/channels/health`
+
+Per-channel health status with detail strings for degraded/unhealthy channels.
+
+**Response 200:**
+```json
+[
+  {"name": "discord-main", "status": "healthy",  "detail": ""},
+  {"name": "slack-main",   "status": "degraded", "detail": "reconnecting, last error: ..."}
+]
+```
+
+```bash
+curl http://localhost:8080/admin/channels/health \
+  -H 'Authorization: Bearer <token>'
+```
+
+---
+
+## Cron
+
+### `GET /cron/jobs`
+
+Snapshot of all configured cron job statuses.
+
+**Auth required:** yes (when token configured)
+
+**Response 200:**
+```json
+[
+  {
+    "name": "daily-digest",
+    "schedule": "24h",
+    "enabled": true,
+    "last_run": "2026-03-18T00:00:00Z",
+    "next_run": "2026-03-19T00:00:00Z",
+    "run_count": 7
+  }
+]
+```
+
+---
+
+## User Preferences
+
+### `GET /users/:user_id/preferences`
+
+Get cross-channel routing preferences for a user.
+
+**Response 200:**
+```json
+{"user_id": "u1", "preferred_channel": "discord-main"}
+```
+
+---
+
+### `POST /users/:user_id/preferences`
+
+Set the preferred response channel for a user.
+
+**Body:**
+```json
+{"preferred_channel": "slack-main"}
+```
+
+**Response 200:** `{"user_id": "u1", "preferred_channel": "slack-main"}`
+
+---
+
+## OpenAI-Compatible Endpoint
+
+### `POST /v1/chat/completions`
+
+OpenAI-compatible chat completions. Accepts OpenAI SDK clients.
+
+**Auth required:** yes (when token configured) — use the same bearer token
+**Content-Type:** `application/json`
+
+**Request body:**
+```json
+{
+  "model": "rustynail",
+  "messages": [
+    {"role": "user", "content": "Hello!"}
+  ],
+  "stream": false
+}
+```
+
+**Non-streaming response (200):**
+```json
+{
+  "id": "chatcmpl-...",
+  "object": "chat.completion",
+  "model": "rustynail",
+  "choices": [
+    {
+      "index": 0,
+      "message": {"role": "assistant", "content": "Hello! How can I help?"},
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18}
+}
+```
+
+**SSE streaming (`"stream": true`):**
+
+```
+data: {"id":"chatcmpl-...","object":"chat.completion.chunk","choices":[{"delta":{"content":"Hello"},"index":0}]}
+
+data: {"id":"chatcmpl-...","object":"chat.completion.chunk","choices":[{"delta":{"content":"!"},"index":0}]}
+
+data: [DONE]
+```
+
+---
+
+## Test Channel
+
+Only available when `channels.test_channel: true`. Never enable in production.
+
+### `POST /test/send`
+
+Inject a message into the test channel.
+
+**Body:**
+```json
+{"user_id": "u1", "content": "hello world"}
+```
+
+**Response 200:** `{"queued": true}`
+
+```bash
+curl -X POST http://localhost:8080/test/send \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id":"u1","content":"hello"}'
+```
+
+---
+
+### `GET /test/responses`
+
+Drain all pending bot responses from the test channel.
+
+**Response 200:**
+```json
+[
+  {"user_id": "u1", "content": "Hello! I received: hello"}
+]
+```
+
+```bash
+curl http://localhost:8080/test/responses
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,295 @@
+# Architecture
+
+## Overview
+
+RustyNail is a single statically-linked binary built on async Rust (Tokio). It runs as an event-driven message gateway: inbound messages from any channel flow through an 8-stage pipeline into per-user AI agents, then back out through the originating (or preferred) channel.
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  RustyNail Gateway (Single Binary, Tokio Runtime)                            │
+│                                                                              │
+│  ┌────────────────────────────────────────────────────────────────────────┐ │
+│  │  HTTP Server (Axum :8080)                                               │ │
+│  │                                                                          │ │
+│  │  Health & Observability                                                  │ │
+│  │    GET  /health /ready /live /status /metrics                           │ │
+│  │                                                                          │ │
+│  │  Web Dashboard                                                           │ │
+│  │    GET  /dashboard /dashboard/data                                      │ │
+│  │    WS   /dashboard/ws  ← live push (stats_update, message_event)       │ │
+│  │                                                                          │ │
+│  │  Channel Webhooks                                                        │ │
+│  │    POST /webhooks/whatsapp  /webhooks/telegram  /webhooks/slack         │ │
+│  │    POST /webhooks/sms  /webhooks/teams  /webhooks/:name                 │ │
+│  │                                                                          │ │
+│  │  Webchat                                                                 │ │
+│  │    WS   /channels/webchat/ws   GET /channels/webchat/widget.js          │ │
+│  │                                                                          │ │
+│  │  Admin & Management                                                      │ │
+│  │    DELETE /admin/memory/:id  POST /admin/skills/reload                  │ │
+│  │    GET    /admin/channels/health                                         │ │
+│  │    GET    /cron/jobs                                                     │ │
+│  │    GET/POST /users/:id/preferences                                       │ │
+│  │                                                                          │ │
+│  │  OpenAI-Compatible                                                       │ │
+│  │    POST /v1/chat/completions  (non-streaming + SSE)                     │ │
+│  │                                                                          │ │
+│  │  Test Channel                                                            │ │
+│  │    POST /test/send  GET /test/responses                                  │ │
+│  └────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ┌────────────────────────────────────────────────────────────────────────┐ │
+│  │  Gateway Core                                                           │ │
+│  │  ┌─────────────┐  ┌──────────────────┐  ┌────────────────────────┐   │ │
+│  │  │  Channel     │  │  Message Router  │  │  Hot Config            │   │ │
+│  │  │  Registry    │  │  (tokio::mpsc)   │  │  (Arc<RwLock<...>>)   │   │ │
+│  │  └─────────────┘  └──────────────────┘  └────────────────────────┘   │ │
+│  └────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ┌──────────────────────────────────────────────────────────────────┐       │
+│  │  Channels (12)              │  Mode        │ Direction            │       │
+│  │  Discord                    │  Gateway WS  │ bidirectional        │       │
+│  │  WhatsApp                   │  Webhook     │ bidirectional        │       │
+│  │  Telegram                   │  Webhook     │ bidirectional        │       │
+│  │  Telegram Long-Poll         │  Long-poll   │ bidirectional        │       │
+│  │  Slack                      │  Webhook     │ bidirectional        │       │
+│  │  Slack Socket Mode          │  Socket WS   │ bidirectional        │       │
+│  │  SMS / Twilio               │  Webhook     │ bidirectional        │       │
+│  │  Microsoft Teams            │  Webhook     │ bidirectional        │       │
+│  │  Email                      │  IMAP+SMTP   │ bidirectional        │       │
+│  │  Webchat                    │  WebSocket   │ bidirectional        │       │
+│  │  Generic Webhook            │  Webhook     │ inbound only         │       │
+│  │  Test Channel               │  HTTP inject │ bidirectional        │       │
+│  └──────────────────────────────────────────────────────────────────┘       │
+│                                                                              │
+│  ┌──────────────────────────────────────────────────────────────────┐       │
+│  │  Message Pipeline (8 stages)                                      │       │
+│  │  1. Deduplication (SHA-256 ring buffer)                           │       │
+│  │  2. Audit log (NDJSON, async mpsc writer)                         │       │
+│  │  3. Rate limiting (per-user sliding window, DashMap)              │       │
+│  │  4. Attachment routing (PDF/image → agent prompt prefix)          │       │
+│  │  5. Memory write (backend store)                                  │       │
+│  │  6. Summarization (async, fire-and-forget)                        │       │
+│  │  7. Agent processing (retry + jitter + fallback chain)            │       │
+│  │  8. Response formatting + chunking + channel send                 │       │
+│  └──────────────────────────────────────────────────────────────────┘       │
+│                                                                              │
+│  ┌────────────────────────┐   ┌──────────────────┐   ┌─────────────────┐  │
+│  │  Agent Manager          │   │  Memory Backends │   │  Tool Registry  │  │
+│  │  Per-user Conversational│   │  inmemory        │   │  calculator     │  │
+│  │  Agents (agenkit-rust)  │   │  redis           │   │  formatter      │  │
+│  │  7 LLM providers        │   │  sqlite          │   │  filesystem     │  │
+│  │  Retry + jitter         │   │  postgres        │   │  web-search     │  │
+│  │  Fallback chain         │   │  vector          │   │  web-fetch      │  │
+│  │  Token streaming        │   │  (temporal decay)│   │  pdf-analysis   │  │
+│  └────────────────────────┘   └──────────────────┘   │  image-analysis │  │
+│                                                        │  shell          │  │
+│  ┌────────────────────────┐   ┌──────────────────┐   │  calendar       │  │
+│  │  MCP                   │   │  Skills          │   └─────────────────┘  │
+│  │  Server (stdio)         │   │  SKILL.md files  │                        │
+│  │  Client (stdio/http)    │   │  injected into   │   ┌─────────────────┐  │
+│  └────────────────────────┘   │  system prompts  │   │  Cron Scheduler │  │
+│                                └──────────────────┘   │  Synthetic msgs │  │
+│                                                        └─────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Message Pipeline (8 Stages)
+
+Every inbound message from any channel flows through `handle_message_inner()` in this order:
+
+### Stage 1: Deduplication
+
+`MessageDeduplicator` maintains a SHA-256 ring buffer of `(user_id, content_hash)` pairs. Duplicate messages within the configured window are dropped before any further processing.
+
+- Controlled by: `gateway.deduplication.enabled` / `gateway.deduplication.window_size`
+- When a message is dropped: silent discard, no agent call, no response
+
+### Stage 2: Audit Log
+
+`AuditLogger` writes a `message_received` event to the NDJSON audit log before any processing. This ensures all inbound messages are recorded even if they are later rate-limited or cause an error.
+
+- Controlled by: `audit.enabled` / `audit.path`
+
+### Stage 3: Rate Limiting
+
+`RateLimiter` enforces a per-user sliding-window limit using `DashMap`. Users who exceed the limit receive a friendly warning message instead of an agent response; the pipeline exits here.
+
+- Controlled by: `gateway.rate_limit.*`
+- Emits: `rate_limit_hit` audit event + increments `rustynail_rate_limit_hits_total`
+
+### Stage 4: Attachment Routing
+
+When `gateway.auto_route_attachments` is enabled and the message contains `Attachment` structs:
+- `pdf` attachment → prepends `"Please analyze this PDF: {url}"` to the agent prompt
+- `image` attachment → prepends `"Please describe this image: {url}"` to the agent prompt
+
+### Stage 5: Memory Write
+
+The inbound message is written to the configured memory backend for this user. This happens before the agent call so the conversation context is always up to date.
+
+### Stage 6: Summarization (async, fire-and-forget)
+
+After writing to memory, `MemorySummarizer::maybe_summarize()` is called as a background task (`tokio::spawn`). It checks whether the history exceeds `summarization.trigger_at` (message count) or `summarization.trigger_token_budget` (token estimate). If triggered, it calls the configured LLM to generate a `[Summary: ...]` entry and replaces the oldest messages.
+
+### Stage 7: Agent Processing
+
+`AgentManager::process_message()` looks up or creates the per-user `ConversationalAgent` and calls the LLM. Retry and fallback logic runs here:
+
+- **Retry**: exponential backoff with optional ±20% jitter; up to `agents.retry.max_attempts` attempts
+- **Fallback chain**: on capacity/overload errors, `FallbackAgent` tries each `agents.fallback_providers` entry in order
+- **Streaming**: `process_message_stream()` emits 5-byte chunks via mpsc channel (used by webchat WS and `/v1/chat/completions` SSE)
+
+### Stage 8: Response Formatting + Chunking + Send
+
+1. **`ResponseFormatter`**: converts markdown to platform-native syntax based on `channel_id` prefix:
+   - Slack: `**bold**` → `*bold*`, links → `<url|text>`
+   - Telegram: `**bold**` → `*bold*`, MarkdownV2 special-char escaping
+   - WhatsApp: `**bold**` → `*bold*`, links → `text (url)`
+   - Discord/Teams: pass-through
+   - Code blocks are protected from inline substitution
+2. **`MessageChunker`**: splits responses exceeding the platform character limit at whitespace boundaries (built-in defaults: Discord→2000, Slack→4000, Teams→1024, Telegram/WhatsApp→4096)
+3. **Channel send**: each chunk is sent to the user's preferred channel via the channel's `send()` method
+
+## Channel Adapter Pattern
+
+Each channel implements the `Channel` trait:
+
+```rust
+#[async_trait]
+pub trait Channel: Send + Sync {
+    fn name(&self) -> &str;
+    async fn start(&mut self, tx: mpsc::Sender<Message>) -> Result<()>;
+    async fn send(&self, msg: &Message) -> Result<()>;
+    async fn stop(&self) -> Result<()>;
+    async fn health(&self) -> ChannelHealth;
+}
+```
+
+**Webhook channels** (WhatsApp, Telegram, Slack, SMS, Teams, Generic, Test): registered with the gateway and receive messages via Axum handlers which push into an `mpsc::Sender<Message>`.
+
+**Active channels** (Discord, Telegram long-poll, Slack Socket Mode, Email): spawn background tasks that independently receive messages and push them into the gateway's message sender.
+
+## Agent Manager
+
+`AgentManager` maintains a `DashMap<String, ConversationalAgent>` — one agent per `user_id`. Agents are created on first message and reused for all subsequent messages from the same user.
+
+`create_llm()` builds the LLM provider from config:
+1. Creates the primary provider
+2. Wraps it with `FallbackAgent` if `fallback_providers` is configured
+3. Applies retry logic to the resulting provider
+
+`process_message_stream()` requires `Arc<Self>` and returns an `mpsc::Receiver<StreamEvent>` that yields `Token(String)` and `Done` variants. The webchat WS handler and OpenAI-compat SSE endpoint consume this channel.
+
+## Memory Backends
+
+All backends implement the `MemoryStore` trait:
+
+```rust
+#[async_trait]
+pub trait MemoryStore: Send + Sync {
+    async fn add_message(&self, user_id: &str, message: Message) -> Result<()>;
+    async fn get_history(&self, user_id: &str) -> Result<Vec<Message>>;
+    async fn clear(&self, user_id: &str) -> Result<()>;
+}
+```
+
+| Backend | Implementation | Notes |
+|---------|---------------|-------|
+| `inmemory` | `DashMap<String, VecDeque<Message>>` | Lost on restart; default |
+| `redis` | `redis` blocking client via `spawn_blocking` | TTL-based expiry |
+| `sqlite` | `rusqlite` single-threaded runtime bridge | WAL mode; history trimmed on insert |
+| `postgres` | `sqlx` async pool | Auto-creates `rustynail_messages` table |
+| `vector` | agenkit `VectorMemory` + ring buffer | Temporal decay scoring + semantic search |
+
+**Vector memory temporal decay**: each message is stored with a timestamp. `get_history()` returns messages sorted by `recency_weight = exp(-age_seconds / half_life)`. At `half_life` age, weight ≈ 0.5; at `2 × half_life`, weight ≈ 0.25.
+
+## Hot-Reload (SIGHUP)
+
+`HotConfig` wraps the subset of config that can be updated at runtime:
+
+| Field | Notes |
+|-------|-------|
+| `log_level` | Affects new log records |
+| `api_token` | Bearer auth reads from HotConfig on every request |
+| `rate_limit.*` | Applied to subsequent windows; does not reset existing counters |
+| `audit.*` | Enables/disables audit logging; path changes take effect immediately |
+
+The bearer auth middleware holds an `Arc<RwLock<HotConfig>>` and acquires a read lock on every request — no restart needed to update the token.
+
+Fields not in HotConfig (memory backend, channels, LLM provider, tool config) require a full restart.
+
+**SIGHUP sequence:**
+1. `main.rs` catches SIGHUP via `tokio::signal::unix`
+2. Calls `Config::load()` to read the current config file / env vars
+3. Calls `hot.write().await.apply(&new_cfg)` which returns a list of changed field names
+4. Logs the changed fields (or "no hot-reloadable changes" if none)
+
+## Observability
+
+### Prometheus Metrics
+
+All metrics are registered at startup and exposed at `GET /metrics`.
+
+Key counters: `messages_in_total`, `messages_out_total`, `auth_failures_total`, `rate_limit_hits_total`, `llm_errors_total`, `llm_retries_total`, `tokens_in_total`, `tokens_out_total`
+
+Key gauges: `active_users`, `healthy_channels`
+
+Key histograms: `message_duration_seconds` (end-to-end pipeline latency)
+
+### OpenTelemetry
+
+When `otel.endpoint` is set, tracing spans are emitted to the OTLP gRPC endpoint:
+
+- `gateway.handle_message` — spans the full pipeline execution
+- `agent.process` — spans the LLM call including retries
+
+### Audit Log
+
+NDJSON events written by `AuditLogger` (async background writer via `mpsc::UnboundedSender`):
+
+| Event | Trigger |
+|-------|---------|
+| `auth_rejected` | Bearer token mismatch |
+| `rate_limit_hit` | User exceeds rate window |
+| `message_received` | Every inbound message |
+| `tool_executed` | After each tool call |
+| `config_reloaded` | SIGHUP with changed fields |
+| `agent_created` | New per-user agent instantiated |
+| `llm_error` | LLM call fails (all attempts) |
+| `AdminAction` | Any Admin API call |
+
+### Dashboard WebSocket Push
+
+`MessageStats` holds a `broadcast::Sender<DashboardEvent>`. On each inbound/outbound message, a `MessageEvent` is broadcast. The dashboard WS handler receives these and pushes `message_event` frames to all connected clients. A background task pushes `stats_update` frames every 5 seconds.
+
+## Source Map
+
+| Path | Purpose |
+|------|---------|
+| `src/main.rs` | CLI parsing, startup, SIGHUP handler, graceful shutdown |
+| `src/lib.rs` | Library root, public re-exports |
+| `src/types.rs` | `Message`, `Attachment`, `Channel`, `AgentResponse`, error enums |
+| `src/config/mod.rs` | All config structs, env var loading, `Config::load()` |
+| `src/gateway/mod.rs` | `Gateway`, `HotConfig`, `handle_message_inner()` |
+| `src/gateway/http.rs` | All Axum route handlers, `AppState`, `HttpServerConfig` |
+| `src/gateway/dashboard.rs` | `MessageStats`, `DashboardEvent`, WS push task |
+| `src/gateway/rate_limiter.rs` | `RateLimiter` (DashMap sliding window) |
+| `src/gateway/deduplicator.rs` | `MessageDeduplicator` (SHA-256 ring buffer) |
+| `src/gateway/chunker.rs` | `MessageChunker` (platform character limits) |
+| `src/gateway/formatter.rs` | `ResponseFormatter` (platform-native markdown) |
+| `src/gateway/openai_compat.rs` | `/v1/chat/completions` handler (SSE streaming) |
+| `src/gateway/user_prefs.rs` | Cross-channel routing preferences |
+| `src/agents/manager.rs` | `AgentManager`, LLM provider factory, streaming |
+| `src/agents/fallback.rs` | `FallbackAgent` (capacity-error fallback chain) |
+| `src/memory/` | All `MemoryStore` implementations |
+| `src/channels/` | All channel adapters |
+| `src/tools/` | All tool implementations |
+| `src/skills/mod.rs` | `SkillRegistry` (SKILL.md discovery) |
+| `src/audit/mod.rs` | `AuditLogger`, `AuditEvent` |
+| `src/cron/` | `CronScheduler` |
+| `benches/` | Criterion benchmark suite |
+| `tests/` | Integration tests |
+| `deploy/` | Helm chart, Prometheus alerts, Grafana dashboard |

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,0 +1,399 @@
+# Channel Setup Guides
+
+RustyNail supports 12 channels. This guide walks through the prerequisites, credential steps, and configuration for each one.
+
+## 1. Discord
+
+### Prerequisites
+
+- A Discord account with server admin permissions
+- Rust 1.75+ and RustyNail built
+
+### Steps
+
+1. Go to https://discord.com/developers/applications and create a **New Application**.
+2. Navigate to **Bot** → **Add Bot**.
+3. Copy the **Token** (this is your `DISCORD_BOT_TOKEN`).
+4. Under **Privileged Gateway Intents**, enable **Message Content Intent**.
+5. Go to **OAuth2 → URL Generator**: select `bot` scope, then `Send Messages` and `Read Messages/View Channels` permissions.
+6. Use the generated URL to invite the bot to your server.
+
+### Config
+
+```yaml
+channels:
+  discord:
+    enabled: true
+    auth:
+      token: ${DISCORD_BOT_TOKEN}
+```
+
+Or: `export DISCORD_BOT_TOKEN=<your-token>`
+
+### Verification
+
+Start RustyNail and send a message to your bot in Discord. It should reply.
+
+### Notes
+
+- Discord uses the serenity gateway (persistent WebSocket) — no public URL required.
+- The bot only receives messages where it is mentioned (or in DMs).
+
+---
+
+## 2. WhatsApp
+
+### Prerequisites
+
+- Meta Business account with WhatsApp Cloud API enabled
+- A phone number registered with Meta
+- A public HTTPS URL for the webhook (use ngrok for local testing)
+
+### Steps
+
+1. Go to https://developers.facebook.com, create an app, and add **WhatsApp** product.
+2. In **WhatsApp → Configuration**, note your **Phone Number ID** and generate a **System User Access Token**.
+3. Set a **Verify Token** (any string you choose).
+4. Set the webhook URL to: `https://your-domain/webhooks/whatsapp`
+5. Subscribe to the `messages` field.
+
+### Config
+
+```yaml
+channels:
+  whatsapp:
+    enabled: true
+    phone_number_id: ${WHATSAPP_PHONE_NUMBER_ID}
+    access_token: ${WHATSAPP_ACCESS_TOKEN}
+    verify_token: ${WHATSAPP_VERIFY_TOKEN}
+```
+
+### Webhook URLs
+
+- `GET /webhooks/whatsapp` — Meta webhook verification (challenge-response)
+- `POST /webhooks/whatsapp` — inbound messages
+
+### Notes
+
+- Graph API version used: v18.0
+- Long messages are automatically chunked if `gateway.chunking_enabled: true` (limit: 4096 chars).
+
+---
+
+## 3. Telegram (Webhook)
+
+### Prerequisites
+
+- A Telegram account
+- A public HTTPS URL for the webhook
+
+### Steps
+
+1. Open Telegram and message `@BotFather`. Send `/newbot` and follow the prompts.
+2. Copy the **bot token** (format: `123456789:ABCdef...`).
+3. Choose a **webhook secret** (any random string ≥32 chars recommended).
+4. Register the webhook:
+   ```bash
+   curl "https://api.telegram.org/bot<TOKEN>/setWebhook" \
+     -d "url=https://your-domain/webhooks/telegram" \
+     -d "secret_token=<YOUR_SECRET>"
+   ```
+
+### Config
+
+```yaml
+channels:
+  telegram:
+    enabled: true
+    bot_token: ${TELEGRAM_BOT_TOKEN}
+    webhook_secret: ${TELEGRAM_WEBHOOK_SECRET}
+    mode: webhook
+```
+
+### Webhook URL
+
+`POST /webhooks/telegram` — receives `X-Telegram-Bot-Api-Secret-Token` header for verification.
+
+---
+
+## 4. Telegram (Long-Poll)
+
+Use this mode when you cannot expose a public URL (e.g. local dev or behind a firewall).
+
+### Config
+
+```yaml
+channels:
+  telegram:
+    enabled: true
+    bot_token: ${TELEGRAM_BOT_TOKEN}
+    mode: longpoll
+```
+
+Or: `TELEGRAM_MODE=longpoll`
+
+RustyNail spawns a background loop calling `getUpdates?timeout=30` with automatic offset tracking. No public URL required. On error it waits 5 seconds and retries.
+
+---
+
+## 5. Slack (Events API Webhook)
+
+### Prerequisites
+
+- Slack workspace admin access
+- A public HTTPS URL for the webhook
+
+### Steps
+
+1. Go to https://api.slack.com/apps and create a **New App** from scratch.
+2. Under **OAuth & Permissions → Scopes**, add `chat:write`, `channels:history`, `im:history`.
+3. Install the app to your workspace and copy the **Bot User OAuth Token** (`xoxb-`).
+4. Under **Basic Information → App Credentials**, copy the **Signing Secret**.
+5. Under **Event Subscriptions**, enable events and set the Request URL to `https://your-domain/webhooks/slack`. Subscribe to `message.channels` and `message.im` bot events.
+
+### Config
+
+```yaml
+channels:
+  slack:
+    enabled: true
+    bot_token: ${SLACK_BOT_TOKEN}
+    signing_secret: ${SLACK_SIGNING_SECRET}
+    mode: webhook
+```
+
+### Webhook URLs
+
+- `POST /webhooks/slack` — receives events; verifies HMAC-SHA256 signature using `X-Slack-Signature` header.
+
+---
+
+## 6. Slack (Socket Mode)
+
+Use Socket Mode when you cannot expose a public URL.
+
+### Additional Steps
+
+1. Under **Socket Mode**, enable it and generate an **App-Level Token** with `connections:write` scope. It starts with `xapp-`.
+
+### Config
+
+```yaml
+channels:
+  slack:
+    enabled: true
+    bot_token: ${SLACK_BOT_TOKEN}
+    mode: socket
+    app_token: ${SLACK_APP_TOKEN}
+```
+
+Or: `SLACK_MODE=socket SLACK_APP_TOKEN=xapp-...`
+
+No public URL required. RustyNail opens a persistent WebSocket to Slack's infrastructure with exponential backoff reconnection.
+
+---
+
+## 7. SMS / Twilio
+
+### Prerequisites
+
+- Twilio account (https://www.twilio.com)
+- A Twilio phone number
+- A public HTTPS URL for the webhook
+
+### Steps
+
+1. In the Twilio Console, note your **Account SID** and **Auth Token**.
+2. Purchase or use an existing Twilio phone number.
+3. In the number's settings, set the **Messaging webhook** to: `https://your-domain/webhooks/sms` (HTTP POST, TwiML).
+
+### Config
+
+```yaml
+channels:
+  sms:
+    enabled: true
+    auth:
+      account_sid: ${TWILIO_ACCOUNT_SID}
+      auth_token: ${TWILIO_AUTH_TOKEN}
+      from_number: "+15551234567"
+```
+
+### Webhook URL
+
+`POST /webhooks/sms` — receives Twilio `Body`, `From`, `To` form fields and returns empty TwiML. Outbound SMS is sent via the Twilio Messages REST API.
+
+---
+
+## 8. Microsoft Teams
+
+### Prerequisites
+
+- Azure account and Microsoft Teams workspace
+- A public HTTPS URL for the Bot Framework webhook
+
+### Steps
+
+1. Go to https://dev.botframework.com and register a **new bot**.
+2. Note the **App ID** and generate an **App Password** (client secret).
+3. Set the messaging endpoint to: `https://your-domain/channels/teams/messages`
+4. In Teams Admin, add the bot as a channel.
+
+### Config
+
+```yaml
+channels:
+  teams:
+    enabled: true
+    auth:
+      app_id: ${TEAMS_APP_ID}
+      app_password: ${TEAMS_APP_PASSWORD}
+      hmac_secret: ${TEAMS_HMAC_SECRET}  # optional
+```
+
+### HMAC Validation
+
+Set `hmac_secret` (env: `TEAMS_HMAC_SECRET`) to enable HMAC-SHA256 validation of inbound Bot Framework activities using the `Authorization: HMAC <hex>` header. Empty = skip validation (backward compatible).
+
+### Webhook URL
+
+`POST /channels/teams/messages`
+
+RustyNail uses OAuth2 client credentials (App ID + Password) to obtain Bearer tokens for outbound sends, with 60-second pre-refresh caching.
+
+---
+
+## 9. Email (IMAP + SMTP)
+
+### Prerequisites
+
+- An email account with IMAP access enabled (e.g. Gmail with "Allow less secure apps" or an App Password)
+- IMAP and SMTP host/port details
+
+### Config
+
+```yaml
+channels:
+  email:
+    enabled: true
+    imap:
+      host: imap.gmail.com
+      port: 993
+      username: ${EMAIL_USERNAME}
+      password: ${EMAIL_PASSWORD}
+      inbox: INBOX
+    smtp:
+      host: smtp.gmail.com
+      port: 587
+      username: ${EMAIL_USERNAME}
+      password: ${EMAIL_PASSWORD}
+      from_address: bot@example.com
+```
+
+### Notes
+
+- IMAP is polled every 30 seconds using a sync client on a dedicated thread.
+- HTML email and quoted-text reply headers are automatically stripped.
+- Use an **App Password** for Gmail accounts with 2FA (not your regular password).
+- `~` in paths is expanded to the home directory.
+
+---
+
+## 10. Webchat
+
+Serves a self-contained JavaScript widget that users can embed in any web page.
+
+### Config
+
+```yaml
+channels:
+  webchat:
+    enabled: true
+    allowed_origins:
+      - https://myapp.example.com
+    welcome_message: "Hello! How can I help you today?"
+```
+
+Or: `WEBCHAT_ENABLED=true WEBCHAT_ALLOWED_ORIGINS=https://myapp.example.com`
+
+### Embedding the widget
+
+Add this to your HTML page:
+
+```html
+<script src="https://rustynail.example.com/channels/webchat/widget.js"></script>
+```
+
+The widget (~3KB, no external dependencies) opens a WebSocket connection and renders a chat UI in the bottom-right corner with:
+- Auto-reconnecting WebSocket
+- Token streaming support (messages appear word-by-word)
+- Configurable welcome message
+
+### WebSocket
+
+`GET /channels/webchat/ws?session_id=<uuid>` — session_id must be a UUID; each page load gets a new session.
+
+### CORS / Origins
+
+`allowed_origins` restricts which `Origin` headers are accepted for WebSocket upgrades. Empty = allow all. Note this is separate from `gateway.allowed_ws_origins`, which applies to both the dashboard and webchat sockets.
+
+---
+
+## 11. Generic Webhook
+
+Receive messages from any system that can send HTTP POST requests.
+
+### Config
+
+```yaml
+channels:
+  webhook:
+    enabled: true
+    endpoints:
+      - path: my-crm
+        user_id: crm-user
+        secret: ${CRM_WEBHOOK_SECRET}
+        extract_text: "$.event.message"
+      - path: alerting
+        user_id: alert-bot
+```
+
+### Routes
+
+`POST /webhooks/<path>` — one route per configured endpoint.
+
+### HMAC Verification
+
+If `secret` is set, RustyNail verifies the `X-Hub-Signature-256` header (HMAC-SHA256 of the raw body, format: `sha256=<hex>`). Requests with invalid or missing signatures are rejected with 401.
+
+### Text extraction
+
+`extract_text` is a JSONPath expression (e.g. `$.event.message.text`). When absent, the full raw request body is used as the message text.
+
+---
+
+## 12. Test Channel
+
+A zero-credential development channel for integration testing. **Never enable in production.**
+
+### Config
+
+```yaml
+channels:
+  test_channel: true
+```
+
+### Endpoints
+
+- `POST /test/send` — inject a message:
+  ```bash
+  curl -X POST http://localhost:8080/test/send \
+    -H 'Content-Type: application/json' \
+    -d '{"user_id":"u1","content":"hello"}'
+  ```
+- `GET /test/responses` — drain pending bot responses:
+  ```bash
+  curl http://localhost:8080/test/responses
+  ```
+
+Use with `agents.llm_provider: stub` (echo mode) for fully offline integration tests. See `configs/harness.yaml` for the minimal zero-credential config.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,271 @@
+# CLI Reference
+
+RustyNail is a single binary with 7 subcommands. Running with no subcommand is equivalent to `rustynail start`.
+
+```
+USAGE:
+    rustynail [SUBCOMMAND]
+
+SUBCOMMANDS:
+    start                  Start the gateway (default)
+    status [--port N]      Query a running instance
+    version                Print version and build info
+    config check           Load config and print summary
+    config validate        Preflight checks; exits 0/1
+    completions <shell>    Print shell completion script
+    mcp serve              Expose tools as MCP server (stdio)
+```
+
+---
+
+## `rustynail start`
+
+Start the RustyNail gateway. This is the default when no subcommand is given.
+
+```bash
+rustynail start
+# equivalent to:
+rustynail
+```
+
+**Startup sequence:**
+
+1. Load configuration (`CONFIG_FILE` → env vars → defaults)
+2. Initialise structured logging (with optional OTel exporter)
+3. Create the gateway and register configured channels
+4. Start the HTTP server on `gateway.http_port` (default 8080)
+5. Start the WebSocket server on `gateway.websocket_port` (default 18789)
+6. Register SIGHUP handler for hot-reload (Unix only)
+7. Block until Ctrl-C or SIGTERM
+8. Graceful shutdown with `gateway.shutdown_timeout_seconds` timeout
+
+**Environment variables read at startup:**
+
+All variables listed in the [env var cheat sheet](deployment.md#environment-variables-cheat-sheet).
+
+**SIGHUP behaviour:**
+
+Sending SIGHUP to the running process reloads hot-reloadable config fields without restart. See [deployment.md — SIGHUP Hot-Reload](deployment.md#sighup-hot-reload).
+
+**Graceful shutdown:**
+
+On Ctrl-C or SIGTERM, the gateway stops accepting new messages and waits up to `shutdown_timeout_seconds` for in-flight messages to complete. A warning is logged if the timeout is exceeded.
+
+---
+
+## `rustynail status [--port N]`
+
+Query a running RustyNail instance over HTTP and print the JSON status response.
+
+```bash
+rustynail status
+rustynail status --port 9090
+```
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--port N` | `8080` | HTTP port of the running instance |
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| `0` | Connected successfully; status printed |
+| `1` | Could not connect to the instance |
+
+**Output:** Formatted JSON from `GET /status`. Example:
+
+```json
+{
+  "status": "running",
+  "version": "0.13.0",
+  "uptime_seconds": 3600,
+  "channels": [
+    {"name": "discord-main", "status": "healthy"}
+  ],
+  "active_users": 5
+}
+```
+
+---
+
+## `rustynail version`
+
+Print version and build information.
+
+```bash
+rustynail version
+```
+
+**Output:**
+
+```
+rustynail 0.13.0
+repository: https://github.com/scttfrdmn/rustynail
+license:    Apache-2.0
+```
+
+---
+
+## `rustynail config check`
+
+Load the configuration and print a human-readable summary. Does not start the server.
+
+```bash
+rustynail config check
+CONFIG_FILE=production.yaml rustynail config check
+```
+
+**What it prints:**
+
+```
+Configuration OK
+  HTTP port:        8080
+  WebSocket port:   18789
+  Log level:        info
+  LLM provider:     anthropic
+  LLM model:        claude-3-5-sonnet-20241022
+  Memory backend:   redis
+  Tools enabled:    true
+  Summarization:    enabled (trigger_at=40, keep_recent=10)
+  OTel endpoint:    http://otel-collector:4317
+  Dashboard auth:   enabled
+  Channels:         discord, slack (webhook), telegram (long-poll)
+  Gateway auth:     enabled
+  Skills:           enabled (2 paths, 4 skills loaded)
+  WS origins:       https://myapp.example.com
+  Shutdown timeout: 30s
+  Cron jobs:        2
+  PDF tool:         enabled
+  Image tool:       disabled
+```
+
+**No side effects** — this command only reads config and exits. Safe to run in CI.
+
+---
+
+## `rustynail config validate`
+
+Run preflight validation checks and exit with a clear pass/fail report.
+
+```bash
+rustynail config validate
+CONFIG_FILE=production.yaml rustynail config validate
+echo $?   # 0 = all passed, 1 = one or more failed
+```
+
+**Checks performed:**
+
+| Check | Pass condition | Output |
+|-------|---------------|--------|
+| Config loads | YAML parses without error | `[✓] Config loaded (config.yaml)` |
+| API key present | `agents.api_key` is non-empty | `[✓] API key present (anthropic)` |
+| Redis URL set | When `memory.backend = "redis"` | `[✓] Memory backend: redis (url set)` |
+| SQLite path set | When `memory.backend = "sqlite"` | `[✓] Memory backend: sqlite (path set)` |
+| Postgres URL set | When `memory.backend = "postgres"` | `[✓] Memory backend: postgres (url set)` |
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| `0` | All checks passed |
+| `1` | One or more checks failed |
+
+**Example output (all pass):**
+
+```
+[✓] Config loaded (config.yaml)
+[✓] API key present (anthropic)
+[✓] Memory backend: redis (url set)
+[✓] All checks passed.
+```
+
+**Example output (failure):**
+
+```
+[✓] Config loaded (env vars)
+[✗] API key missing (agents.api_key / ANTHROPIC_API_KEY)
+[✗] Memory backend is sqlite but memory.sqlite_path is not set
+
+2 check(s) failed.
+```
+
+Useful in CI/CD pipelines before deploying: add `rustynail config validate` as a pre-deploy step.
+
+---
+
+## `rustynail completions <shell>`
+
+Print a shell completion script for the given shell to stdout.
+
+```bash
+rustynail completions bash
+rustynail completions zsh
+rustynail completions fish
+rustynail completions powershell
+rustynail completions elvish
+```
+
+**Supported shells:** `bash`, `zsh`, `fish`, `powershell`, `elvish`
+
+**Installation:**
+
+```bash
+# Bash
+rustynail completions bash >> ~/.bash_completion
+# or
+rustynail completions bash > /etc/bash_completion.d/rustynail
+
+# Zsh
+rustynail completions zsh > "${fpath[1]}/_rustynail"
+# or add to ~/.zshrc:
+source <(rustynail completions zsh)
+
+# Fish
+rustynail completions fish > ~/.config/fish/completions/rustynail.fish
+
+# PowerShell (add to $PROFILE)
+rustynail completions powershell | Out-String | Invoke-Expression
+```
+
+---
+
+## `rustynail mcp serve`
+
+Expose RustyNail's registered tools as an MCP (Model Context Protocol) server over stdio.
+
+```bash
+rustynail mcp serve
+```
+
+Pipe this into Claude Code or any MCP-compatible client:
+
+```bash
+# In Claude Code's settings (claude_desktop_config.json):
+{
+  "mcpServers": {
+    "rustynail": {
+      "command": "/usr/local/bin/rustynail",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+**Tools exposed** (depends on config):
+
+- `calculator` — always available
+- `formatter` — always available
+- `filesystem` — when `tools.enabled = true` and `tools.filesystem_root` is set
+- `web_search` — when `tools.enabled = true` and `tools.web_search_api_key` is set
+- `calendar` — when `tools.enabled = true`
+
+**Transport:** stdio (stdin/stdout JSON-RPC). Log output is written to stderr to keep the transport clean.
+
+**Notes:**
+
+- The server reads config from `CONFIG_FILE` / env vars at startup.
+- Tools are registered based on the current config — no `tools.enabled = false` tools will appear.
+- Compatible with Claude Code, Cursor, and any MCP-compliant client.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,7 +80,7 @@ rustynail status --port 9090
 ```json
 {
   "status": "running",
-  "version": "0.13.0",
+  "version": "0.15.0",
   "uptime_seconds": 3600,
   "channels": [
     {"name": "discord-main", "status": "healthy"}
@@ -102,7 +102,7 @@ rustynail version
 **Output:**
 
 ```
-rustynail 0.13.0
+rustynail 0.15.0
 repository: https://github.com/scttfrdmn/rustynail
 license:    Apache-2.0
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,527 @@
+# Configuration Reference
+
+RustyNail is configured through a combination of a YAML file and environment variables.
+
+## Loading Order
+
+Settings are resolved in this priority order (highest wins):
+
+1. **Environment variables** — always override everything else
+2. **`CONFIG_FILE`** — path to a YAML config file (e.g. `CONFIG_FILE=config.yaml`)
+3. **Built-in defaults** — sensible values are applied when nothing is set
+
+Only `ANTHROPIC_API_KEY` (or the equivalent for your chosen provider) is required. All other settings have defaults.
+
+## `gateway.*`
+
+Controls the HTTP server, security, and message pipeline behaviour.
+
+| Field | Type | Env var | Default | Description |
+|-------|------|---------|---------|-------------|
+| `http_port` | `u16` | — | `8080` | HTTP server port |
+| `websocket_port` | `u16` | — | `18789` | WebSocket server port (dashboard + webchat) |
+| `log_level` | `String` | `RUST_LOG` | `"info"` | Log level: `trace`, `debug`, `info`, `warn`, `error` |
+| `api_token` | `Option<String>` | `GATEWAY_API_TOKEN` | `None` | Bearer token for API auth. Empty = auth disabled |
+| `max_body_bytes` | `usize` | `GATEWAY_MAX_BODY_BYTES` | `1048576` (1 MiB) | Maximum request body size. Returns 413 when exceeded |
+| `request_timeout_seconds` | `u64` | `GATEWAY_REQUEST_TIMEOUT_SECONDS` | `30` | Handler timeout in seconds. Returns 408 when exceeded |
+| `allowed_ws_origins` | `Vec<String>` | `GATEWAY_ALLOWED_WS_ORIGINS` (comma-sep) | `[]` (allow all) | Allowed WebSocket upgrade origins. Empty = allow all |
+| `shutdown_timeout_seconds` | `u64` | `GATEWAY_SHUTDOWN_TIMEOUT_SECONDS` | `30` | Graceful shutdown timeout in seconds |
+| `chunking_enabled` | `bool` | `GATEWAY_CHUNKING_ENABLED` | `false` | Split long responses at platform character limits |
+| `chunking_limits` | `HashMap<String,usize>` | — (file only) | built-in per-platform | Per-channel-id character limits; built-ins: `discord`→2000, `slack`→4000, `teams`→1024, `telegram`→4096, `whatsapp`→4096 |
+| `formatting_enabled` | `bool` | `GATEWAY_FORMATTING_ENABLED` | `true` | Convert markdown to platform-native syntax |
+| `auto_route_attachments` | `bool` | `GATEWAY_AUTO_ROUTE_ATTACHMENTS` | `false` | Prepend PDF/image context to agent prompt |
+| `deduplication.enabled` | `bool` | `GATEWAY_DEDUP_ENABLED` | `false` | Drop duplicate `(user_id, content)` pairs |
+| `deduplication.window_size` | `usize` | `GATEWAY_DEDUP_WINDOW_SIZE` | `256` | Ring buffer size for deduplication hashes |
+
+### `gateway.rate_limit.*`
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `enabled` | `RATE_LIMIT_ENABLED` | `false` | Enable per-user sliding-window rate limiting |
+| `messages_per_window` | `RATE_LIMIT_MESSAGES` | `20` | Maximum messages allowed per window |
+| `window_seconds` | `RATE_LIMIT_WINDOW_SECONDS` | `60` | Window size in seconds |
+
+**Example:**
+
+```yaml
+gateway:
+  http_port: 8080
+  websocket_port: 18789
+  log_level: info
+  api_token: ${GATEWAY_API_TOKEN}
+  max_body_bytes: 2097152     # 2 MiB
+  request_timeout_seconds: 30
+  shutdown_timeout_seconds: 30
+  allowed_ws_origins:
+    - https://myapp.example.com
+  chunking_enabled: true
+  formatting_enabled: true
+  auto_route_attachments: true
+  deduplication:
+    enabled: true
+    window_size: 512
+  rate_limit:
+    enabled: true
+    messages_per_window: 20
+    window_seconds: 60
+```
+
+## `channels.*`
+
+Each channel is optional. Absent or `enabled: false` means the channel is inactive.
+
+### Discord
+
+```yaml
+channels:
+  discord:
+    enabled: true
+    auth:
+      token: ${DISCORD_BOT_TOKEN}
+```
+
+| Field | Env var | Required | Description |
+|-------|---------|----------|-------------|
+| `enabled` | — | — | Activate this channel |
+| `auth.token` | `DISCORD_BOT_TOKEN` | yes | Bot token from Discord Developer Portal |
+
+### WhatsApp
+
+```yaml
+channels:
+  whatsapp:
+    enabled: true
+    phone_number_id: "1234567890"
+    access_token: ${WHATSAPP_ACCESS_TOKEN}
+    verify_token: ${WHATSAPP_VERIFY_TOKEN}
+```
+
+| Field | Env var | Required | Description |
+|-------|---------|----------|-------------|
+| `phone_number_id` | `WHATSAPP_PHONE_NUMBER_ID` | yes | Meta Cloud API phone number ID |
+| `access_token` | `WHATSAPP_ACCESS_TOKEN` | yes | Meta System User access token |
+| `verify_token` | `WHATSAPP_VERIFY_TOKEN` | yes | Webhook verification token |
+
+Webhook URL: `POST /webhooks/whatsapp`
+
+### Telegram
+
+```yaml
+channels:
+  telegram:
+    enabled: true
+    bot_token: ${TELEGRAM_BOT_TOKEN}
+    webhook_secret: ${TELEGRAM_WEBHOOK_SECRET}
+    mode: webhook   # or: longpoll
+```
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `bot_token` | `TELEGRAM_BOT_TOKEN` | — | BotFather token |
+| `webhook_secret` | `TELEGRAM_WEBHOOK_SECRET` | — | Secret token sent in `X-Telegram-Bot-Api-Secret-Token` header |
+| `mode` | `TELEGRAM_MODE` | `"webhook"` | `"webhook"` or `"longpoll"` |
+
+Webhook URL (webhook mode): `POST /webhooks/telegram`
+
+### Slack
+
+```yaml
+channels:
+  slack:
+    enabled: true
+    bot_token: ${SLACK_BOT_TOKEN}
+    signing_secret: ${SLACK_SIGNING_SECRET}
+    mode: webhook   # or: socket
+    app_token: ${SLACK_APP_TOKEN}  # required for socket mode
+```
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `bot_token` | `SLACK_BOT_TOKEN` | — | Bot token (`xoxb-`) |
+| `signing_secret` | `SLACK_SIGNING_SECRET` | — | Used to verify HMAC-SHA256 request signatures |
+| `mode` | `SLACK_MODE` | `"webhook"` | `"webhook"` or `"socket"` |
+| `app_token` | `SLACK_APP_TOKEN` | — | App-level token (`xapp-`), required for socket mode |
+
+Webhook URL (webhook mode): `POST /webhooks/slack`
+
+### SMS / Twilio
+
+```yaml
+channels:
+  sms:
+    enabled: true
+    auth:
+      account_sid: ${TWILIO_ACCOUNT_SID}
+      auth_token: ${TWILIO_AUTH_TOKEN}
+      from_number: "+15551234567"
+```
+
+Webhook URL: `POST /webhooks/sms`
+
+### Microsoft Teams
+
+```yaml
+channels:
+  teams:
+    enabled: true
+    auth:
+      app_id: ${TEAMS_APP_ID}
+      app_password: ${TEAMS_APP_PASSWORD}
+      hmac_secret: ${TEAMS_HMAC_SECRET}   # optional
+```
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `auth.app_id` | `TEAMS_APP_ID` | — | Bot Framework app registration ID |
+| `auth.app_password` | `TEAMS_APP_PASSWORD` | — | Bot Framework app password |
+| `auth.hmac_secret` | `TEAMS_HMAC_SECRET` | `""` | Optional HMAC-SHA256 validation secret. Empty = skip |
+
+Webhook URL: `POST /channels/teams/messages`
+
+### Email
+
+```yaml
+channels:
+  email:
+    enabled: true
+    imap:
+      host: imap.gmail.com
+      port: 993
+      username: ${EMAIL_USERNAME}
+      password: ${EMAIL_PASSWORD}
+      inbox: INBOX
+    smtp:
+      host: smtp.gmail.com
+      port: 587
+      username: ${EMAIL_USERNAME}
+      password: ${EMAIL_PASSWORD}
+      from_address: bot@example.com
+```
+
+| Field | Env var | Default |
+|-------|---------|---------|
+| `imap.host` | `EMAIL_IMAP_HOST` | — |
+| `imap.port` | `EMAIL_IMAP_PORT` | `993` |
+| `imap.username` | `EMAIL_USERNAME` | — |
+| `imap.password` | `EMAIL_PASSWORD` | — |
+| `imap.inbox` | `EMAIL_INBOX` | `"INBOX"` |
+| `smtp.host` | `EMAIL_SMTP_HOST` | — |
+| `smtp.port` | `EMAIL_SMTP_PORT` | `587` |
+| `smtp.from_address` | `EMAIL_FROM_ADDRESS` | — |
+
+### Webchat
+
+```yaml
+channels:
+  webchat:
+    enabled: true
+    allowed_origins:
+      - https://myapp.example.com
+    welcome_message: "Hello! How can I help?"
+```
+
+| Field | Env var | Default |
+|-------|---------|---------|
+| `allowed_origins` | `WEBCHAT_ALLOWED_ORIGINS` (comma-sep) | `[]` |
+| `welcome_message` | `WEBCHAT_WELCOME_MESSAGE` | — |
+
+WebSocket: `GET /channels/webchat/ws?session_id=<uuid>`
+Widget: `GET /channels/webchat/widget.js`
+
+### Generic Webhook
+
+```yaml
+channels:
+  webhook:
+    enabled: true
+    endpoints:
+      - path: my-system
+        user_id: webhook-user
+        secret: ${MY_WEBHOOK_SECRET}
+        extract_text: "$.message.text"
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `path` | yes | Path segment → `POST /webhooks/<path>` |
+| `user_id` | yes | User ID for all messages from this endpoint |
+| `secret` | no | HMAC-SHA256 verification secret |
+| `extract_text` | no | JSONPath to extract message text. Falls back to full body |
+
+### Test Channel
+
+```yaml
+channels:
+  test_channel: true
+```
+
+Enables `POST /test/send` (inject a message) and `GET /test/responses` (drain pending responses). Used by the zero-credential test harness. Never enable in production.
+
+## `agents.*`
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `llm_provider` | `LLM_PROVIDER` | `"anthropic"` | Provider: `anthropic`, `openai`, `ollama`, `gemini`, `bedrock`, `litellm`, `openai-compat`, `stub` |
+| `llm_model` | — | `"claude-3-5-sonnet-20241022"` | Model name for the primary provider |
+| `api_key` | `ANTHROPIC_API_KEY` | — | API key for the primary provider |
+| `api_base` | `ANTHROPIC_API_BASE` | — | Override API base URL (e.g. for a proxy) |
+| `max_history` | — | `20` | Conversation history window per user |
+| `temperature` | — | `0.7` | LLM temperature |
+| `aws_region` | `AWS_REGION` | `"us-east-1"` | AWS region (Bedrock only) |
+| `planning_enabled` | `AGENTS_PLANNING_ENABLED` | `false` | Enable `/plan <task>` routing to planning agent |
+| `retry.enabled` | `AGENTS_RETRY_ENABLED` | `true` | LLM retry with exponential backoff |
+| `retry.max_attempts` | `AGENTS_RETRY_MAX_ATTEMPTS` | `3` | Maximum attempts including the first |
+| `retry.base_delay_ms` | `AGENTS_RETRY_BASE_DELAY_MS` | `100` | Base delay in ms for first retry |
+| `retry.jitter_enabled` | `AGENT_RETRY_JITTER_ENABLED` | `false` | Apply ±20% jitter to backoff delays |
+
+### Provider quick-reference
+
+| `llm_provider` | Required env var | Notes |
+|----------------|-----------------|-------|
+| `anthropic` | `ANTHROPIC_API_KEY` | Default |
+| `openai` | `OPENAI_API_KEY` | |
+| `ollama` | — | Set `api_base` to Ollama URL |
+| `gemini` | `GEMINI_API_KEY` | |
+| `bedrock` | AWS credentials | Set `aws_region` |
+| `litellm` | provider-specific | Set `api_base` to LiteLLM proxy URL |
+| `openai-compat` | provider-specific | Set `api_base` to compatible endpoint |
+| `stub` | — | Echo mode; for tests only |
+
+### Fallback providers (file-only)
+
+```yaml
+agents:
+  llm_provider: anthropic
+  api_key: ${ANTHROPIC_API_KEY}
+  fallback_providers:
+    - provider: openai
+      model: gpt-4o
+      api_key: ${OPENAI_API_KEY}
+    - provider: ollama
+      model: llama3
+      api_base: http://localhost:11434
+      api_key: ""
+```
+
+Fallbacks are tried in order on capacity/overload errors (HTTP 500, 503, "overloaded", "model not found"). Rate-limit errors (429) are not forwarded.
+
+## `memory.*`
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `backend` | `MEMORY_BACKEND` | `"inmemory"` | `inmemory`, `redis`, `sqlite`, `postgres`, `vector` |
+| `redis_url` | `REDIS_URL` | — | Required when `backend = "redis"` |
+| `redis_ttl_seconds` | `REDIS_TTL_SECONDS` | `0` (no expiry) | Redis key TTL |
+| `sqlite_path` | `SQLITE_PATH` | — | Required when `backend = "sqlite"` |
+| `postgres_url` | `DATABASE_URL` | — | Required when `backend = "postgres"` |
+| `vector_store` | — | `"memory"` | `"memory"` or `"qdrant"` |
+| `vector_store_url` | — | — | Qdrant URL (when `vector_store = "qdrant"`) |
+| `embedding_provider` | — | `"simple"` | Embedding provider (`"simple"` = deterministic n-gram) |
+| `embedding_model` | — | `""` | Model name (provider-specific; ignored for `"simple"`) |
+| `vector_decay_half_life_seconds` | `VECTOR_DECAY_HALF_LIFE_SECONDS` | `3600.0` | Half-life for temporal decay scoring in vector memory |
+
+### Redis
+
+```yaml
+memory:
+  backend: redis
+  redis_url: redis://localhost:6379
+  redis_ttl_seconds: 86400   # 24 hours
+```
+
+### SQLite
+
+```yaml
+memory:
+  backend: sqlite
+  sqlite_path: /data/rustynail.db
+```
+
+### Postgres
+
+```yaml
+memory:
+  backend: postgres
+  postgres_url: postgresql://user:pass@localhost:5432/rustynail
+```
+
+### Vector (in-process + Qdrant)
+
+```yaml
+memory:
+  backend: vector
+  vector_store: qdrant
+  vector_store_url: http://localhost:6333
+  vector_decay_half_life_seconds: 1800.0   # 30 min
+```
+
+### Summarization
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `summarization.enabled` | `SUMMARIZATION_ENABLED` | `false` | Enable conversation summarization |
+| `summarization.trigger_at` | `SUMMARIZATION_TRIGGER_AT` | `40` | Summarize when history exceeds N messages |
+| `summarization.keep_recent` | `SUMMARIZATION_KEEP_RECENT` | `10` | Messages to keep after summarization |
+| `summarization.model` | `SUMMARIZATION_MODEL` | `"claude-3-haiku-20240307"` | LLM for generating summaries |
+| `summarization.trigger_token_budget` | `SUMMARIZATION_TRIGGER_TOKEN_BUDGET` | `0` (disabled) | Also summarize when estimated tokens exceed this |
+
+```yaml
+memory:
+  backend: redis
+  redis_url: redis://localhost:6379
+  summarization:
+    enabled: true
+    trigger_at: 40
+    keep_recent: 10
+    model: claude-3-haiku-20240307
+    trigger_token_budget: 8000
+```
+
+## `tools.*`
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `enabled` | — | `false` | Master switch for the tool registry |
+| `max_steps` | — | `5` | Maximum ReAct agent steps per message |
+| `filesystem_root` | — | — | Sandbox root for filesystem tool |
+| `web_search_api_key` | `TAVILY_API_KEY` | — | Tavily API key for web search tool |
+| `pdf_enabled` | `TOOLS_PDF_ENABLED` | `false` | Enable PDF analysis tool |
+| `image_enabled` | `TOOLS_IMAGE_ENABLED` | `false` | Enable image analysis tool |
+| `shell.enabled` | — | `false` | Enable shell execution tool |
+| `shell.require_approval` | — | `true` | Require `approved=true` before executing |
+| `shell.allowed_commands` | — | `[]` (any) | Command prefix allowlist |
+
+```yaml
+tools:
+  enabled: true
+  max_steps: 5
+  filesystem_root: /data/files
+  web_search_api_key: ${TAVILY_API_KEY}
+  pdf_enabled: true
+  image_enabled: true
+  shell:
+    enabled: true
+    require_approval: true
+    allowed_commands:
+      - "echo"
+      - "ls"
+```
+
+## `skills.*`
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `enabled` | `SKILLS_ENABLED` | `false` | Enable the skills system |
+| `paths` | `SKILLS_PATHS` (colon-sep) | `["skills/"]` | Directories to search for `SKILL.md` files |
+| `max_active` | `SKILLS_MAX_ACTIVE` | `3` | Maximum skills injected per agent system prompt |
+
+A skill is a directory containing a `SKILL.md` file. The file content is injected verbatim into the agent's system prompt. Example: `skills/my-skill/SKILL.md`.
+
+```yaml
+skills:
+  enabled: true
+  paths:
+    - skills/
+    - /etc/rustynail/skills/
+  max_active: 5
+```
+
+## `audit.*`
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `enabled` | `AUDIT_ENABLED` | `false` | Enable structured audit logging |
+| `path` | `AUDIT_PATH` | `""` (stderr) | File path for NDJSON audit log |
+
+**AuditEvent variants** (all written as NDJSON):
+
+| Variant | Fields | Trigger |
+|---------|--------|---------|
+| `auth_rejected` | `endpoint`, `reason` | Bearer token mismatch |
+| `rate_limit_hit` | `user_id`, `channel_id` | User exceeds rate limit |
+| `message_received` | `user_id`, `channel_id`, `content_len` | Every inbound message |
+| `tool_executed` | `tool_name`, `user_id`, `success` | After each tool call |
+| `config_reloaded` | `changed_fields` | SIGHUP reload |
+| `agent_created` | `user_id` | New per-user agent instantiated |
+| `llm_error` | `user_id`, `error`, `attempt` | LLM call fails |
+| `AdminAction` | `endpoint`, `param`, `success` | Admin API call |
+
+```yaml
+audit:
+  enabled: true
+  path: /var/log/rustynail/audit.ndjson
+```
+
+## `cron.*`
+
+```yaml
+cron:
+  jobs:
+    - name: daily-digest
+      schedule: 24h
+      message: "Generate a daily summary of recent activity."
+      channel_id: discord-main
+      user_id: cron-digest
+      enabled: true
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Human-readable label for logs |
+| `schedule` | yes | Interval with suffix: `30s`, `5m`, `2h`, `1d` |
+| `message` | yes | Message text injected on each tick |
+| `channel_id` | yes | Channel to route the synthetic message to |
+| `user_id` | yes | User ID for the synthetic message |
+| `enabled` | no (default true) | Whether this job is active |
+
+View job statuses: `GET /cron/jobs`
+
+## `mcp.*`
+
+```yaml
+mcp:
+  servers:
+    - name: my-tools
+      transport: stdio
+      command: /usr/local/bin/my-mcp-server
+      args: ["--config", "/etc/mcp.yaml"]
+      env:
+        - ["MY_SECRET", "${MY_SECRET}"]
+    - name: remote-tools
+      transport: http
+      url: http://mcp-server:8090
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `transport` | `"stdio"` | `"stdio"` (subprocess) or `"http"` |
+| `command` | — | Command to spawn (stdio only) |
+| `args` | `[]` | Arguments for the subprocess |
+| `env` | `[]` | Extra env vars as `[["KEY","VALUE"],...]` |
+| `url` | — | Base URL (http only) |
+
+Misconfigured or unreachable servers are logged and skipped at startup.
+
+## `otel.*`
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `endpoint` | `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OTLP gRPC endpoint. Empty = tracing disabled |
+| `service_name` | — | `"rustynail"` | Service name in traces |
+
+```yaml
+otel:
+  endpoint: http://otel-collector:4317
+  service_name: rustynail-prod
+```
+
+## `dashboard.*`
+
+| Field | Env var | Default | Description |
+|-------|---------|---------|-------------|
+| `auth_password` | `DASHBOARD_AUTH_PASSWORD` | — | HTTP Basic Auth password for dashboard. Empty = no auth. Username is always `rustynail` |
+
+```yaml
+dashboard:
+  auth_password: ${DASHBOARD_AUTH_PASSWORD}
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -389,7 +389,7 @@ memory:
 | `image_enabled` | `TOOLS_IMAGE_ENABLED` | `false` | Enable image analysis tool |
 | `shell.enabled` | — | `false` | Enable shell execution tool |
 | `shell.require_approval` | — | `true` | Require `approved=true` before executing |
-| `shell.allowed_commands` | — | `[]` (any) | Command prefix allowlist |
+| `shell.allowed_commands` | — | `[]` (any) | Allowlist of permitted commands, matched token-wise |
 
 ```yaml
 tools:
@@ -405,7 +405,35 @@ tools:
     allowed_commands:
       - "echo"
       - "ls"
+      - "git status"
 ```
+
+### How `shell.allowed_commands` is enforced
+
+Entries are matched **token-wise against the parsed argv**, not as raw string
+prefixes. An entry constrains the program and any leading subcommands it names,
+leaving later arguments free:
+
+| Entry | Permits | Rejects |
+|---|---|---|
+| `git` | `git status`, `git log --oneline` | `gitleaks detect` |
+| `git status` | `git status --short` | `git push` |
+
+A **non-empty allowlist also changes how commands run**: the command is exec'd
+directly instead of being passed to `sh -c`, so shell features are unavailable —
+pipes, redirection, command substitution, globbing, and `&&`/`;` chaining. Any
+command containing `; | & $ ` > <` or a newline is rejected with an error.
+Quotes still group arguments containing spaces (`git commit -m 'two words'`).
+
+With an **empty** allowlist the command is passed to `sh -c` unchanged and full
+shell semantics apply. That is the permissive default; it grants arbitrary
+execution to whatever can call the tool, so pair it with `require_approval: true`.
+
+> **Note:** prior to v0.15.0 the allowlist prefix-matched the raw command string
+> and then ran it through `sh -c`, so an entry of `git` also permitted
+> `git status; rm -rf ~`. If you relied on shell syntax inside an allowlisted
+> command, it will now be rejected — split it into separate tool calls, or clear
+> the allowlist to opt back into full shell semantics.
 
 ## `skills.*`
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,337 @@
+# Deployment Guide
+
+This guide covers every deployment target: Docker, Docker Compose, Kubernetes via Helm, and bare-metal.
+
+## Docker (Pre-built Image)
+
+A distroless image (~8 MB) is published to GitHub Container Registry on every version tag.
+
+```bash
+docker pull ghcr.io/scttfrdmn/rustynail:latest
+
+docker run --rm \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  -e DISCORD_BOT_TOKEN=... \
+  -p 8080:8080 \
+  ghcr.io/scttfrdmn/rustynail:latest
+```
+
+To use a config file, mount it and set `CONFIG_FILE`:
+
+```bash
+docker run --rm \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  -e CONFIG_FILE=/etc/rustynail/config.yaml \
+  -v $(pwd)/config.yaml:/etc/rustynail/config.yaml:ro \
+  -p 8080:8080 \
+  ghcr.io/scttfrdmn/rustynail:latest
+```
+
+The image runs as distroless `nonroot` (uid 65532) and has no shell or package manager.
+
+## Docker Compose (Local Development)
+
+> **Important**: The build context must be the **parent directory** of `rustynail/` because `agenkit` is a local path dependency at `../agenkit/agenkit-rust`.
+
+```bash
+# From the parent directory (one level above rustynail/)
+cd ..
+
+# Start with env vars
+ANTHROPIC_API_KEY=sk-ant-... \
+DISCORD_BOT_TOKEN=... \
+docker-compose -f rustynail/docker-compose.yml up
+
+# Or use a .env file in the parent directory
+echo "ANTHROPIC_API_KEY=sk-ant-..." > .env
+docker-compose -f rustynail/docker-compose.yml up
+```
+
+**With persistent Redis memory:**
+
+Add Redis to your compose or use the `--profile redis` if your compose defines it:
+
+```yaml
+# Snippet to add to docker-compose.yml
+services:
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis_data:/data
+
+volumes:
+  redis_data:
+```
+
+Then set `MEMORY_BACKEND=redis` and `REDIS_URL=redis://redis:6379`.
+
+## Kubernetes via Helm
+
+### Prerequisites
+
+- Kubernetes 1.21+
+- Helm 3.x
+- An image accessible to your cluster (`ghcr.io/scttfrdmn/rustynail` or your own registry)
+
+### Install
+
+```bash
+helm install rustynail ./deploy/helm/rustynail \
+  --set secrets.anthropicApiKey=sk-ant-... \
+  --set image.tag=0.13.0
+```
+
+### Key `values.yaml` overrides
+
+```yaml
+# Image
+image:
+  repository: ghcr.io/scttfrdmn/rustynail
+  tag: "0.13.0"
+  pullPolicy: IfNotPresent
+
+# Replicas and autoscaling
+replicaCount: 2
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+
+# Secrets (set via --set or external secret manager)
+secrets:
+  anthropicApiKey: ""
+  discordBotToken: ""
+  gatewayApiToken: ""
+  teamsAppId: ""
+  teamsAppPassword: ""
+
+# Ingress
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: rustynail.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: rustynail-tls
+      hosts:
+        - rustynail.example.com
+
+# Redis subchart for persistent memory
+redis:
+  enabled: true
+  auth:
+    enabled: false
+
+memory:
+  backend: redis
+  redisUrl: redis://rustynail-redis-master:6379
+
+# SQLite with PVC
+memory:
+  backend: sqlite
+  sqlitePath: /data/rustynail.db
+# Add a PVC and volumeMount in your values override
+```
+
+### Upgrade
+
+```bash
+helm upgrade rustynail ./deploy/helm/rustynail \
+  --set image.tag=0.14.0 \
+  --reuse-values
+```
+
+### Uninstall
+
+```bash
+helm uninstall rustynail
+```
+
+## Environment Variables Cheat Sheet
+
+Complete list of all environment variables and their config path equivalents.
+
+| Env var | Config path | Required | Default |
+|---------|-------------|----------|---------|
+| `ANTHROPIC_API_KEY` | `agents.api_key` | **yes** | — |
+| `DISCORD_BOT_TOKEN` | `channels.discord.auth.token` | if Discord | — |
+| `CONFIG_FILE` | — | no | — |
+| `RUST_LOG` | `gateway.log_level` | no | `info` |
+| `GATEWAY_API_TOKEN` | `gateway.api_token` | no | — |
+| `GATEWAY_MAX_BODY_BYTES` | `gateway.max_body_bytes` | no | `1048576` |
+| `GATEWAY_REQUEST_TIMEOUT_SECONDS` | `gateway.request_timeout_seconds` | no | `30` |
+| `GATEWAY_SHUTDOWN_TIMEOUT_SECONDS` | `gateway.shutdown_timeout_seconds` | no | `30` |
+| `GATEWAY_ALLOWED_WS_ORIGINS` | `gateway.allowed_ws_origins` | no | — |
+| `GATEWAY_CHUNKING_ENABLED` | `gateway.chunking_enabled` | no | `false` |
+| `GATEWAY_FORMATTING_ENABLED` | `gateway.formatting_enabled` | no | `true` |
+| `GATEWAY_AUTO_ROUTE_ATTACHMENTS` | `gateway.auto_route_attachments` | no | `false` |
+| `GATEWAY_DEDUP_ENABLED` | `gateway.deduplication.enabled` | no | `false` |
+| `GATEWAY_DEDUP_WINDOW_SIZE` | `gateway.deduplication.window_size` | no | `256` |
+| `RATE_LIMIT_ENABLED` | `gateway.rate_limit.enabled` | no | `false` |
+| `RATE_LIMIT_MESSAGES` | `gateway.rate_limit.messages_per_window` | no | `20` |
+| `RATE_LIMIT_WINDOW_SECONDS` | `gateway.rate_limit.window_seconds` | no | `60` |
+| `LLM_PROVIDER` | `agents.llm_provider` | no | `anthropic` |
+| `AGENTS_RETRY_ENABLED` | `agents.retry.enabled` | no | `true` |
+| `AGENTS_RETRY_MAX_ATTEMPTS` | `agents.retry.max_attempts` | no | `3` |
+| `AGENTS_RETRY_BASE_DELAY_MS` | `agents.retry.base_delay_ms` | no | `100` |
+| `AGENT_RETRY_JITTER_ENABLED` | `agents.retry.jitter_enabled` | no | `false` |
+| `MEMORY_BACKEND` | `memory.backend` | no | `inmemory` |
+| `REDIS_URL` | `memory.redis_url` | if redis | — |
+| `REDIS_TTL_SECONDS` | `memory.redis_ttl_seconds` | no | `0` |
+| `SQLITE_PATH` | `memory.sqlite_path` | if sqlite | — |
+| `DATABASE_URL` | `memory.postgres_url` | if postgres | — |
+| `VECTOR_DECAY_HALF_LIFE_SECONDS` | `memory.vector_decay_half_life_seconds` | no | `3600.0` |
+| `SUMMARIZATION_ENABLED` | `memory.summarization.enabled` | no | `false` |
+| `SUMMARIZATION_TRIGGER_AT` | `memory.summarization.trigger_at` | no | `40` |
+| `SUMMARIZATION_KEEP_RECENT` | `memory.summarization.keep_recent` | no | `10` |
+| `SUMMARIZATION_MODEL` | `memory.summarization.model` | no | `claude-3-haiku-20240307` |
+| `SUMMARIZATION_TRIGGER_TOKEN_BUDGET` | `memory.summarization.trigger_token_budget` | no | `0` |
+| `TOOLS_PDF_ENABLED` | `tools.pdf_enabled` | no | `false` |
+| `TOOLS_IMAGE_ENABLED` | `tools.image_enabled` | no | `false` |
+| `TAVILY_API_KEY` | `tools.web_search_api_key` | if web-search | — |
+| `SKILLS_ENABLED` | `skills.enabled` | no | `false` |
+| `SKILLS_PATHS` | `skills.paths` | no | `skills/` |
+| `SKILLS_MAX_ACTIVE` | `skills.max_active` | no | `3` |
+| `AUDIT_ENABLED` | `audit.enabled` | no | `false` |
+| `AUDIT_PATH` | `audit.path` | no | stderr |
+| `DASHBOARD_AUTH_PASSWORD` | `dashboard.auth_password` | no | — |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `otel.endpoint` | no | — |
+| `WHATSAPP_PHONE_NUMBER_ID` | `channels.whatsapp.phone_number_id` | if WhatsApp | — |
+| `WHATSAPP_ACCESS_TOKEN` | `channels.whatsapp.access_token` | if WhatsApp | — |
+| `WHATSAPP_VERIFY_TOKEN` | `channels.whatsapp.verify_token` | if WhatsApp | — |
+| `TELEGRAM_BOT_TOKEN` | `channels.telegram.bot_token` | if Telegram | — |
+| `TELEGRAM_WEBHOOK_SECRET` | `channels.telegram.webhook_secret` | no | — |
+| `TELEGRAM_MODE` | `channels.telegram.mode` | no | `webhook` |
+| `SLACK_BOT_TOKEN` | `channels.slack.bot_token` | if Slack | — |
+| `SLACK_SIGNING_SECRET` | `channels.slack.signing_secret` | if Slack webhook | — |
+| `SLACK_APP_TOKEN` | `channels.slack.app_token` | if Slack socket | — |
+| `SLACK_MODE` | `channels.slack.mode` | no | `webhook` |
+| `TWILIO_ACCOUNT_SID` | `channels.sms.auth.account_sid` | if SMS | — |
+| `TWILIO_AUTH_TOKEN` | `channels.sms.auth.auth_token` | if SMS | — |
+| `TWILIO_FROM_NUMBER` | `channels.sms.auth.from_number` | if SMS | — |
+| `TEAMS_APP_ID` | `channels.teams.auth.app_id` | if Teams | — |
+| `TEAMS_APP_PASSWORD` | `channels.teams.auth.app_password` | if Teams | — |
+| `TEAMS_HMAC_SECRET` | `channels.teams.auth.hmac_secret` | no | — |
+| `EMAIL_IMAP_HOST` | `channels.email.imap.host` | if Email | — |
+| `EMAIL_SMTP_HOST` | `channels.email.smtp.host` | if Email | — |
+| `EMAIL_USERNAME` | `channels.email.imap.username` | if Email | — |
+| `EMAIL_PASSWORD` | `channels.email.imap.password` | if Email | — |
+| `WEBCHAT_ENABLED` | `channels.webchat.enabled` | no | `false` |
+| `WEBCHAT_ALLOWED_ORIGINS` | `channels.webchat.allowed_origins` | no | — |
+| `WEBCHAT_WELCOME_MESSAGE` | `channels.webchat.welcome_message` | no | — |
+| `ANTHROPIC_API_BASE` | `agents.api_base` | no | — |
+| `AWS_REGION` | `agents.aws_region` | if Bedrock | `us-east-1` |
+
+## Health Checks & Kubernetes Probes
+
+| Endpoint | Purpose | Returns non-200 when |
+|----------|---------|----------------------|
+| `GET /live` | Liveness probe | Process is in a bad state |
+| `GET /ready` | Readiness probe | Gateway not yet started |
+| `GET /health` | Load balancer check | Never (always 200 while running) |
+| `GET /status` | Detailed status | N/A (always 200, JSON body) |
+
+**Kubernetes probe YAML:**
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /live
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 30
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+`/live` and `/ready` are always exempt from bearer token auth, even when `GATEWAY_API_TOKEN` is set.
+
+## Prometheus & Grafana
+
+### Prometheus scrape config
+
+```yaml
+scrape_configs:
+  - job_name: rustynail
+    static_configs:
+      - targets: ['rustynail:8080']
+    metrics_path: /metrics
+```
+
+The `/metrics` endpoint returns Prometheus text format (content-type `text/plain; version=0.0.4`).
+
+### Key metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `rustynail_messages_in_total` | Counter | Inbound messages |
+| `rustynail_messages_out_total` | Counter | Outbound messages |
+| `rustynail_active_users` | Gauge | Current unique users |
+| `rustynail_healthy_channels` | Gauge | Channels in healthy state |
+| `rustynail_message_duration_seconds` | Histogram | End-to-end processing time |
+| `rustynail_tokens_in_total` | Counter | LLM input tokens |
+| `rustynail_tokens_out_total` | Counter | LLM output tokens |
+| `rustynail_auth_failures_total` | Counter | Bearer auth rejections |
+| `rustynail_rate_limit_hits_total` | Counter | Rate limit hits |
+| `rustynail_llm_errors_total` | Counter | LLM call errors |
+| `rustynail_llm_retries_total` | Counter | LLM retry attempts |
+
+### Grafana
+
+Import `deploy/grafana/dashboard.json` into Grafana. The provisioning config is at `deploy/grafana/provisioning/dashboards/rustynail.yml`.
+
+Alert rules are in `deploy/prometheus/alerts.yaml`: `RustyNailDown`, `HighMessageLatency`, `ChannelUnhealthy`, `HighErrorRate`, `NoActiveUsers`.
+
+## SIGHUP Hot-Reload
+
+Some config fields update at runtime without restart. Send `SIGHUP` to trigger a reload:
+
+```bash
+# Find the PID
+pgrep rustynail
+
+# Send SIGHUP
+kill -HUP <pid>
+```
+
+**Hot-reloadable fields:**
+
+- `gateway.log_level`
+- `gateway.api_token`
+- `gateway.rate_limit.*`
+- `audit.*`
+
+Fields not in this list (channels, memory backend, LLM provider) require a full restart.
+
+**Kubernetes equivalent:**
+
+```bash
+kubectl exec -it <pod> -- kill -HUP 1
+# or trigger a rolling restart:
+kubectl rollout restart deployment/rustynail
+```
+
+## Production Checklist
+
+Before going live, verify:
+
+- [ ] `GATEWAY_API_TOKEN` set — all non-probe endpoints require bearer auth
+- [ ] `AUDIT_ENABLED=true` and `AUDIT_PATH` points to a writable file or volume
+- [ ] `rate_limit.enabled: true` with appropriate `messages_per_window` / `window_seconds`
+- [ ] Persistent memory backend configured (Redis, SQLite, or Postgres) — `inmemory` loses history on restart
+- [ ] `OTEL_EXPORTER_OTLP_ENDPOINT` set if you want distributed traces
+- [ ] `gateway.allowed_ws_origins` set to your frontend domains (empty = allow all)
+- [ ] `gateway.shutdown_timeout_seconds` tuned for your workload (default 30s)
+- [ ] `DASHBOARD_AUTH_PASSWORD` set if the dashboard is externally accessible
+- [ ] Liveness and readiness probes configured in your orchestrator
+- [ ] Prometheus scrape configured and Grafana dashboard imported
+- [ ] Image pinned to a specific version tag, not `latest`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -78,7 +78,7 @@ Then set `MEMORY_BACKEND=redis` and `REDIS_URL=redis://redis:6379`.
 ```bash
 helm install rustynail ./deploy/helm/rustynail \
   --set secrets.anthropicApiKey=sk-ant-... \
-  --set image.tag=0.13.0
+  --set image.tag=0.15.0
 ```
 
 ### Key `values.yaml` overrides
@@ -87,7 +87,7 @@ helm install rustynail ./deploy/helm/rustynail \
 # Image
 image:
   repository: ghcr.io/scttfrdmn/rustynail
-  tag: "0.13.0"
+  tag: "0.15.0"
   pullPolicy: IfNotPresent
 
 # Replicas and autoscaling
@@ -141,7 +141,7 @@ memory:
 
 ```bash
 helm upgrade rustynail ./deploy/helm/rustynail \
-  --set image.tag=0.14.0 \
+  --set image.tag=0.15.0 \
   --reuse-values
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,350 @@
+# Troubleshooting
+
+## Startup Failures
+
+### `ANTHROPIC_API_KEY not set` / API key missing
+
+```
+Error: API key missing (agents.api_key / ANTHROPIC_API_KEY)
+```
+
+**Fix:** Set the environment variable before starting:
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Or add it to your `config.yaml`:
+```yaml
+agents:
+  api_key: ${ANTHROPIC_API_KEY}
+```
+
+Run `rustynail config validate` to confirm it is detected.
+
+---
+
+### Config load failed (YAML parse error)
+
+```
+Error: Config load failed: ...
+```
+
+**Fix:** Run `rustynail config check` for a human-readable summary, or `rustynail config validate` for preflight checks. Common causes:
+
+- Indentation errors in YAML (use 2 spaces, not tabs)
+- Unquoted strings containing special characters (`:`, `{`, `}`)
+- Referencing an env var that is not set: `${VAR}` expands to empty string — check the var is exported
+
+---
+
+### Port already in use
+
+```
+Error: ... Address already in use (os error 98)
+```
+
+**Fix:** Find and stop the conflicting process:
+```bash
+lsof -i :8080
+kill -TERM <pid>
+```
+
+Or change the port in your config:
+```yaml
+gateway:
+  http_port: 9090
+```
+
+---
+
+### Cannot connect to Redis / Postgres / SQLite
+
+```
+Error: Memory backend connection failed
+```
+
+**Fix for Redis:**
+```bash
+# Test connectivity
+redis-cli -u redis://localhost:6379 ping
+# Should return: PONG
+```
+
+Check `memory.redis_url` is correct and Redis is running.
+
+**Fix for Postgres:**
+```bash
+psql $DATABASE_URL -c "SELECT 1"
+```
+
+Check the connection string format: `postgresql://user:password@host:5432/dbname`
+
+**Fix for SQLite:**
+Check that the directory exists and is writable:
+```bash
+ls -la $(dirname /path/to/rustynail.db)
+```
+
+---
+
+## Channel Connection Issues
+
+### Discord: bot not responding
+
+1. Check the bot token is valid: `DISCORD_BOT_TOKEN` must be a full bot token, not a client secret.
+2. Verify **Message Content Intent** is enabled in the Discord Developer Portal under your app → Bot.
+3. Check the bot has been invited to the server with `Send Messages` and `Read Messages` permissions.
+4. Look for errors in logs: `RUST_LOG=debug cargo run 2>&1 | grep discord`
+
+### WhatsApp: webhook verification fails (403)
+
+The `verify_token` in your config must exactly match the token set in Meta's webhook configuration.
+
+```bash
+curl "https://your-domain/webhooks/whatsapp?hub.mode=subscribe&hub.verify_token=YOUR_TOKEN&hub.challenge=test"
+# Should return: test
+```
+
+### Telegram: bot not receiving messages
+
+For webhook mode: verify `setWebhook` was called and returns `ok: true`:
+```bash
+curl "https://api.telegram.org/bot<TOKEN>/getWebhookInfo"
+```
+
+For long-poll mode: check for errors in logs — the long-poll loop logs connection errors.
+
+Ensure the `webhook_secret` in config matches what was set in `setWebhook`.
+
+### Slack: signature verification failing (401)
+
+```
+warn: Slack signature verification failed
+```
+
+Causes:
+- `signing_secret` is wrong — copy it from Slack App → Basic Information → App Credentials
+- Request timestamp is stale (>5 minutes old) — check system clock sync
+- Body was modified by a proxy — ensure raw bytes reach the handler
+
+### Microsoft Teams: HMAC validation rejected
+
+If `teams.auth.hmac_secret` is set, the `Authorization: HMAC <hex>` header must be present and valid. To disable validation, unset `TEAMS_HMAC_SECRET` (empty = skip).
+
+---
+
+## No Response to Messages
+
+### Step 1: Check /status
+
+```bash
+curl http://localhost:8080/status
+```
+
+Look at `channels` — if a channel shows `"status": "degraded"` or `"unhealthy"`, the issue is at the channel layer.
+
+### Step 2: Check /admin/channels/health
+
+```bash
+curl http://localhost:8080/admin/channels/health \
+  -H 'Authorization: Bearer <token>'
+```
+
+This returns per-channel `health_detail` strings with error context for degraded channels.
+
+### Step 3: Enable debug logging
+
+```bash
+RUST_LOG=debug cargo run 2>&1 | tee rustynail.log
+```
+
+Look for:
+- `rate_limit_hit` — user is being rate-limited (friendly message sent instead of agent response)
+- `dedup: dropping duplicate` — message was deduplicated
+- `llm_error` — LLM call is failing; check API key and provider status
+- `agent_created` vs `agent reused` — confirm the user is being recognized
+
+### Step 4: Check rate limiting
+
+```bash
+curl http://localhost:8080/metrics | grep rate_limit
+# rustynail_rate_limit_hits_total 3
+```
+
+If the counter is increasing, users are hitting the rate limit. Adjust `gateway.rate_limit.messages_per_window` or `window_seconds`.
+
+### Step 5: Use the test channel
+
+The test channel bypasses all channel auth and is useful for isolating issues:
+
+```bash
+# config.yaml: channels: { test_channel: true }
+curl -X POST http://localhost:8080/test/send \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id":"debug-user","content":"hello"}'
+
+sleep 2
+
+curl http://localhost:8080/test/responses
+```
+
+If the test channel works but Discord does not, the issue is in the Discord channel adapter.
+
+---
+
+## Memory Backend Issues
+
+### Redis: connection refused
+
+```
+WARN: Redis connection failed, falling back to in-memory
+```
+
+Check Redis is running and reachable:
+```bash
+redis-cli ping
+```
+
+The `redis://` URL must include the correct host:port. For Docker Compose, use the service name: `redis://redis:6379`.
+
+### SQLite: permission denied
+
+```
+Error: unable to open database file
+```
+
+Ensure the directory exists and the process has write permission:
+```bash
+mkdir -p /data && chmod 777 /data
+# or run as the correct user
+```
+
+### Postgres: relation does not exist
+
+RustyNail auto-creates the `rustynail_messages` table on first use. If this fails (e.g. the user lacks CREATE TABLE permission), grant the permission:
+```sql
+GRANT CREATE ON SCHEMA public TO rustynail;
+```
+
+### History lost on restart
+
+You are using the default `inmemory` backend. Switch to a persistent backend:
+```yaml
+memory:
+  backend: redis
+  redis_url: redis://localhost:6379
+```
+
+---
+
+## Performance Tuning
+
+### Reducing memory usage per user
+
+Reduce the history window:
+```yaml
+agents:
+  max_history: 10   # default 20
+```
+
+Enable summarization to compress old context:
+```yaml
+memory:
+  summarization:
+    enabled: true
+    trigger_at: 20
+    keep_recent: 5
+```
+
+### Handling high message volume
+
+1. Enable rate limiting to protect the LLM API from overuse:
+   ```yaml
+   gateway:
+     rate_limit:
+       enabled: true
+       messages_per_window: 20
+       window_seconds: 60
+   ```
+
+2. Enable deduplication to discard accidental repeats:
+   ```yaml
+   gateway:
+     deduplication:
+       enabled: true
+   ```
+
+3. Add fallback providers so capacity errors on the primary are retried on a secondary:
+   ```yaml
+   agents:
+     fallback_providers:
+       - provider: openai
+         model: gpt-4o-mini
+         api_key: ${OPENAI_API_KEY}
+   ```
+
+4. Enable retry jitter to reduce thundering-herd on multi-instance deployments:
+   ```yaml
+   agents:
+     retry:
+       jitter_enabled: true
+   ```
+
+### Slow response times
+
+Check `rustynail_message_duration_seconds` in metrics — percentile buckets show whether the tail is at the LLM or in the pipeline. The gateway overhead is <1ms; slow responses are almost always LLM latency.
+
+Consider using a faster model (e.g. `claude-3-haiku-20240307`) for the summarization model to reduce background costs:
+```yaml
+memory:
+  summarization:
+    model: claude-3-haiku-20240307
+```
+
+---
+
+## Useful Debug Commands
+
+```bash
+# Validate configuration before starting
+rustynail config validate
+
+# Print configuration summary
+rustynail config check
+
+# Check if the server is running
+rustynail status
+
+# Health check
+curl http://localhost:8080/health
+
+# Detailed status
+curl http://localhost:8080/status
+
+# Channel health (requires bearer auth if configured)
+curl http://localhost:8080/admin/channels/health \
+  -H 'Authorization: Bearer <token>'
+
+# Prometheus metrics
+curl http://localhost:8080/metrics
+
+# Full debug logging
+RUST_LOG=debug cargo run
+
+# Check config loaded from specific file
+CONFIG_FILE=production.yaml rustynail config check
+
+# Test channel round-trip
+curl -X POST http://localhost:8080/test/send \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id":"test","content":"ping"}'
+sleep 1
+curl http://localhost:8080/test/responses
+```
+
+## Getting Help
+
+- [GitHub Issues](https://github.com/scttfrdmn/rustynail/issues) — bug reports and feature requests
+- [CHANGELOG.md](../CHANGELOG.md) — full history of changes
+- [Configuration Reference](configuration.md) — all config fields and env vars
+- [Architecture](architecture.md) — internals and message pipeline details

--- a/src/agents/manager.rs
+++ b/src/agents/manager.rs
@@ -152,15 +152,16 @@ impl AgentManager {
     /// When fallback providers are configured the primary is wrapped in a
     /// `FallbackAgent` that tries each fallback in order on capacity errors.
     async fn create_llm(&self) -> Result<Arc<dyn Agent>> {
-        let primary = self.create_llm_from_config(
-            &self.config.api_key,
-            &self.config.llm_model,
-            self.config.temperature,
-            self.config.api_base.as_deref(),
-            self.config.aws_region.as_deref(),
-            &self.config.llm_provider,
-        )
-        .await?;
+        let primary = self
+            .create_llm_from_config(
+                &self.config.api_key,
+                &self.config.llm_model,
+                self.config.temperature,
+                self.config.api_base.as_deref(),
+                self.config.aws_region.as_deref(),
+                &self.config.llm_provider,
+            )
+            .await?;
 
         if self.config.fallback_providers.is_empty() {
             return Ok(primary);
@@ -214,9 +215,7 @@ impl AgentManager {
                     api_key: api_key.to_string(),
                     model: model.to_string(),
                     temperature: temperature as f64,
-                    api_base: api_base
-                        .unwrap_or("https://api.openai.com/v1")
-                        .to_string(),
+                    api_base: api_base.unwrap_or("https://api.openai.com/v1").to_string(),
                     ..Default::default()
                 };
                 Arc::new(OpenAIAgent::new(config))
@@ -225,9 +224,7 @@ impl AgentManager {
                 let config = OllamaConfig {
                     model: model.to_string(),
                     temperature: temperature as f64,
-                    api_base: api_base
-                        .unwrap_or("http://localhost:11434")
-                        .to_string(),
+                    api_base: api_base.unwrap_or("http://localhost:11434").to_string(),
                     ..Default::default()
                 };
                 Arc::new(OllamaAgent::new(config))
@@ -261,9 +258,7 @@ impl AgentManager {
                 let config = LiteLLMConfig {
                     model: model.to_string(),
                     api_key: Some(api_key.to_string()),
-                    base_url: api_base
-                        .unwrap_or("http://localhost:4000")
-                        .to_string(),
+                    base_url: api_base.unwrap_or("http://localhost:4000").to_string(),
                     temperature: Some(temperature),
                     ..Default::default()
                 };
@@ -273,9 +268,7 @@ impl AgentManager {
                 let config = OpenAICompatibleConfig {
                     model: model.to_string(),
                     api_key: Some(api_key.to_string()),
-                    base_url: api_base
-                        .unwrap_or("http://localhost:8000/v1")
-                        .to_string(),
+                    base_url: api_base.unwrap_or("http://localhost:8000/v1").to_string(),
                     ..Default::default()
                 };
                 Arc::new(OpenAICompatibleAgent::new(config))
@@ -287,9 +280,7 @@ impl AgentManager {
                     model: model.to_string(),
                     max_tokens: 1024,
                     temperature: temperature as f64,
-                    api_base: api_base
-                        .unwrap_or("https://api.anthropic.com")
-                        .to_string(),
+                    api_base: api_base.unwrap_or("https://api.anthropic.com").to_string(),
                     ..Default::default()
                 };
                 Arc::new(AnthropicAgent::new(config))
@@ -406,8 +397,7 @@ impl AgentManager {
                 if let Some(ref stats) = self.stats {
                     stats.record_llm_retry();
                 }
-                let base = self.retry_config.base_delay_ms
-                    * 2u64.saturating_pow(attempt - 1);
+                let base = self.retry_config.base_delay_ms * 2u64.saturating_pow(attempt - 1);
                 let delay_ms = if self.retry_config.jitter_enabled {
                     // ±20%: factor in [0.8, 1.2)
                     let nanos = std::time::SystemTime::now()
@@ -502,8 +492,6 @@ impl AgentManager {
 mod tests {
     use super::*;
     use crate::config::{AgentRetryConfig, AgentsConfig};
-    use agenkit::core::{AgentError, Message as AkMessage};
-    use std::sync::atomic::{AtomicU32, Ordering};
 
     fn stub_config() -> AgentsConfig {
         AgentsConfig {
@@ -531,14 +519,24 @@ mod tests {
         let result = mgr.process_message("user1", "hello").await.unwrap();
         // ConversationalAgent passes full history to the agent; the stub echoes it all.
         // The user message "hello" must appear somewhere in the response.
-        assert!(result.contains("hello"), "expected 'hello' in response, got: {}", result);
-        assert!(result.starts_with("echo:"), "response should start with echo:, got: {}", result);
+        assert!(
+            result.contains("hello"),
+            "expected 'hello' in response, got: {}",
+            result
+        );
+        assert!(
+            result.starts_with("echo:"),
+            "response should start with echo:, got: {}",
+            result
+        );
     }
 
     #[tokio::test]
     async fn test_process_message_stream_emits_done() {
         let mgr = Arc::new(AgentManager::new(stub_config()));
-        let mut rx = mgr.process_message_stream("user1".to_string(), "hi".to_string()).await;
+        let mut rx = mgr
+            .process_message_stream("user1".to_string(), "hi".to_string())
+            .await;
         let mut got_done = false;
         while let Some(event) = rx.recv().await {
             if matches!(event, StreamEvent::Done) {
@@ -552,7 +550,9 @@ mod tests {
     #[tokio::test]
     async fn test_process_message_stream_emits_tokens() {
         let mgr = Arc::new(AgentManager::new(stub_config()));
-        let mut rx = mgr.process_message_stream("user1".to_string(), "hello".to_string()).await;
+        let mut rx = mgr
+            .process_message_stream("user1".to_string(), "hello".to_string())
+            .await;
         let mut assembled = String::new();
         while let Some(event) = rx.recv().await {
             match event {
@@ -562,38 +562,27 @@ mod tests {
             }
         }
         // Stub echoes the full history; "hello" must appear somewhere.
-        assert!(assembled.contains("hello"), "reassembled should contain 'hello', got: {}", assembled);
-        assert!(assembled.starts_with("echo:"), "should start with echo:, got: {}", assembled);
-    }
-
-    /// Agent that always fails, for testing retry behaviour.
-    struct AlwaysFailAgent {
-        calls: Arc<AtomicU32>,
-    }
-
-    #[async_trait::async_trait]
-    impl agenkit::core::Agent for AlwaysFailAgent {
-        fn name(&self) -> &str {
-            "always_fail"
-        }
-
-        async fn process(&self, _input: AkMessage) -> Result<AkMessage, AgentError> {
-            self.calls.fetch_add(1, Ordering::SeqCst);
-            Err(AgentError::ProcessingError("simulated failure".to_string()))
-        }
+        assert!(
+            assembled.contains("hello"),
+            "reassembled should contain 'hello', got: {}",
+            assembled
+        );
+        assert!(
+            assembled.starts_with("echo:"),
+            "should start with echo:, got: {}",
+            assembled
+        );
     }
 
     #[tokio::test]
     async fn test_retry_disabled_calls_once() {
-        let calls = Arc::new(AtomicU32::new(0));
-        // We can't easily inject a custom LLM into AgentManager without changing the API,
-        // but we can test the retry logic via stub: retry disabled means 1 attempt.
-        // Use stub (always succeeds), but test the retry configuration path with retry disabled.
+        // `AgentManager` builds its own agent internally, so a failing agent
+        // can't be injected without an API change. This exercises the
+        // retry-disabled configuration path against the always-succeeding stub;
+        // attempt counting is covered by the fallback tests in `fallback.rs`.
         let mgr = AgentManager::new(retry_config(false, 1));
-        // Stub succeeds, so just verify it works correctly when retry is disabled.
         let result = mgr.process_message("user1", "test").await;
         assert!(result.is_ok());
-        let _ = calls; // unused here since we use stub
     }
 
     #[tokio::test]
@@ -603,7 +592,15 @@ mod tests {
         let result = mgr.process_message("user1", "test").await;
         assert!(result.is_ok());
         let text = result.unwrap();
-        assert!(text.contains("test"), "response should contain 'test', got: {}", text);
-        assert!(text.starts_with("echo:"), "should start with echo:, got: {}", text);
+        assert!(
+            text.contains("test"),
+            "response should contain 'test', got: {}",
+            text
+        );
+        assert!(
+            text.starts_with("echo:"),
+            "should start with echo:, got: {}",
+            text
+        );
     }
 }

--- a/src/channels/email.rs
+++ b/src/channels/email.rs
@@ -86,7 +86,10 @@ impl Channel for EmailChannel {
         let to_addr = if message.user_id.contains('@') {
             message.user_id.clone()
         } else {
-            warn!("EmailChannel: user_id '{}' is not an email address", message.user_id);
+            warn!(
+                "EmailChannel: user_id '{}' is not an email address",
+                message.user_id
+            );
             return Ok(());
         };
 
@@ -94,9 +97,9 @@ impl Channel for EmailChannel {
             .from(smtp_config.from_address.parse().map_err(|e| {
                 anyhow::anyhow!("invalid from address '{}': {}", smtp_config.from_address, e)
             })?)
-            .to(to_addr.parse().map_err(|e| {
-                anyhow::anyhow!("invalid to address '{}': {}", to_addr, e)
-            })?)
+            .to(to_addr
+                .parse()
+                .map_err(|e| anyhow::anyhow!("invalid to address '{}': {}", to_addr, e))?)
             .subject("RustyNail")
             .multipart(
                 MultiPart::alternative().singlepart(
@@ -107,10 +110,7 @@ impl Channel for EmailChannel {
             )
             .map_err(|e| anyhow::anyhow!("email build error: {}", e))?;
 
-        let creds = Credentials::new(
-            smtp_config.username.clone(),
-            smtp_config.password.clone(),
-        );
+        let creds = Credentials::new(smtp_config.username.clone(), smtp_config.password.clone());
 
         let mailer = AsyncSmtpTransport::<Tokio1Executor>::relay(&smtp_config.host)
             .map_err(|e| anyhow::anyhow!("SMTP relay error: {}", e))?
@@ -149,7 +149,10 @@ async fn imap_poll_loop(
     let mut last_uid: u32 = 0;
     let poll_interval = std::time::Duration::from_secs(30);
 
-    info!("Email IMAP poll loop started ({}:{})", config.imap.host, config.imap.port);
+    info!(
+        "Email IMAP poll loop started ({}:{})",
+        config.imap.host, config.imap.port
+    );
 
     loop {
         let host = config.imap.host.clone();
@@ -161,7 +164,15 @@ async fn imap_poll_loop(
         let current_last_uid = last_uid;
 
         let result = tokio::task::spawn_blocking(move || {
-            fetch_new_emails(&host, port, &username, &password, &inbox, &cid, current_last_uid)
+            fetch_new_emails(
+                &host,
+                port,
+                &username,
+                &password,
+                &inbox,
+                &cid,
+                current_last_uid,
+            )
         })
         .await;
 

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1,15 +1,15 @@
-pub mod channel;              // Trait definition
-pub mod discord;              // Discord via serenity
-pub mod email;                // Email (IMAP/SMTP)
-pub mod slack;                // Slack webhook
-pub mod slack_socketmode;     // Slack Socket Mode
-pub mod sms;                  // Twilio SMS
-pub mod teams;                // Microsoft Teams (Bot Framework)
-pub mod telegram;             // Telegram webhook
-pub mod telegram_longpoll;    // Telegram long-poll
-pub mod testchan;             // Zero-credential test channel
-pub mod webhook;              // Generic webhook
-pub mod webchat;              // Web chat widget
-pub mod whatsapp;             // WhatsApp Graph API
+pub mod channel; // Trait definition
+pub mod discord; // Discord via serenity
+pub mod email; // Email (IMAP/SMTP)
+pub mod slack; // Slack webhook
+pub mod slack_socketmode; // Slack Socket Mode
+pub mod sms; // Twilio SMS
+pub mod teams; // Microsoft Teams (Bot Framework)
+pub mod telegram; // Telegram webhook
+pub mod telegram_longpoll; // Telegram long-poll
+pub mod testchan; // Zero-credential test channel
+pub mod webchat; // Web chat widget
+pub mod webhook; // Generic webhook
+pub mod whatsapp; // WhatsApp Graph API
 
-pub use channel::Channel;     // Re-export trait
+pub use channel::Channel; // Re-export trait

--- a/src/channels/slack_socketmode.rs
+++ b/src/channels/slack_socketmode.rs
@@ -195,15 +195,14 @@ async fn socket_mode_loop(
                                 "events_api" => {
                                     // Acknowledge immediately
                                     if !envelope_id.is_empty() {
-                                        let ack =
-                                            serde_json::json!({ "envelope_id": envelope_id });
-                                        let _ = write
-                                            .send(WsMsg::Text(ack.to_string()))
-                                            .await;
+                                        let ack = serde_json::json!({ "envelope_id": envelope_id });
+                                        let _ = write.send(WsMsg::Text(ack.to_string())).await;
                                     }
 
                                     // Parse the inner event
-                                    if let Some(msg) = parse_socket_event(&val, &channel_id, &bot_token) {
+                                    if let Some(msg) =
+                                        parse_socket_event(&val, &channel_id, &bot_token)
+                                    {
                                         if let Err(e) = tx.send(msg) {
                                             error!("Slack Socket Mode: failed to enqueue: {}", e);
                                         }
@@ -212,11 +211,8 @@ async fn socket_mode_loop(
                                 other => {
                                     // Ack any unknown envelope
                                     if !envelope_id.is_empty() {
-                                        let ack =
-                                            serde_json::json!({ "envelope_id": envelope_id });
-                                        let _ = write
-                                            .send(WsMsg::Text(ack.to_string()))
-                                            .await;
+                                        let ack = serde_json::json!({ "envelope_id": envelope_id });
+                                        let _ = write.send(WsMsg::Text(ack.to_string())).await;
                                     }
                                     tracing::debug!("Slack WS: unhandled type '{}'", other);
                                 }
@@ -314,10 +310,5 @@ fn parse_socket_event(val: &Value, channel_id: &str, _bot_token: &str) -> Option
         text.len()
     );
 
-    Some(Message::new(
-        slack_channel,
-        user_id.clone(),
-        user_id,
-        text,
-    ))
+    Some(Message::new(slack_channel, user_id.clone(), user_id, text))
 }

--- a/src/channels/sms.rs
+++ b/src/channels/sms.rs
@@ -86,11 +86,7 @@ impl Channel for SmsChannel {
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            return Err(anyhow::anyhow!(
-                "Twilio API error {}: {}",
-                status,
-                body
-            ));
+            return Err(anyhow::anyhow!("Twilio API error {}: {}", status, body));
         }
 
         Ok(())
@@ -147,9 +143,7 @@ pub fn verify_twilio_signature(
 /// Twilio sends `From`, `To`, `Body`, `MessageSid`, etc. as URL-encoded form fields.
 pub fn parse_sms_webhook(channel_id: &str, form: &[(String, String)]) -> Option<Message> {
     let get = |key: &str| -> Option<String> {
-        form.iter()
-            .find(|(k, _)| k == key)
-            .map(|(_, v)| v.clone())
+        form.iter().find(|(k, _)| k == key).map(|(_, v)| v.clone())
     };
 
     let from = get("From")?;

--- a/src/channels/teams.rs
+++ b/src/channels/teams.rs
@@ -1,12 +1,12 @@
 use crate::channels::Channel;
 use crate::config::TeamsConfig;
-use std::collections::HashMap;
 use crate::types::{ChannelHealth, Message};
 use anyhow::Result;
 use async_trait::async_trait;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
@@ -49,8 +49,7 @@ impl TokenManager {
         }
 
         // Fetch a new token
-        let token_url =
-            "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
+        let token_url = "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
 
         let client = reqwest::Client::new();
         let mut form: HashMap<&str, &str> = HashMap::new();
@@ -87,8 +86,7 @@ impl TokenManager {
             .await
             .map_err(|e| anyhow::anyhow!("failed to parse token response: {}", e))?;
 
-        let expires_at =
-            Instant::now() + Duration::from_secs(token_resp.expires_in);
+        let expires_at = Instant::now() + Duration::from_secs(token_resp.expires_in);
 
         let token = token_resp.access_token.clone();
         *guard = Some(TeamsTokenCache {
@@ -106,7 +104,11 @@ impl TokenManager {
 ///
 /// Teams signs requests with `Authorization: HMAC <hex(hmac_sha256(secret, body))>`.
 /// When `secret` is empty this function always returns `Ok(())` (backward compatible).
-pub fn verify_teams_signature(secret: &str, body: &[u8], authorization: &str) -> anyhow::Result<()> {
+pub fn verify_teams_signature(
+    secret: &str,
+    body: &[u8],
+    authorization: &str,
+) -> anyhow::Result<()> {
     if secret.is_empty() {
         return Ok(());
     }
@@ -183,20 +185,20 @@ pub fn parse_activity(channel_id: &str, activity: &TeamsActivity) -> Option<Mess
 
 pub struct TeamsChannel {
     id: String,
-    config: TeamsConfig,
     token_manager: Arc<TokenManager>,
     running: bool,
 }
 
 impl TeamsChannel {
     pub fn new(id: impl Into<String>, config: TeamsConfig) -> Self {
+        // Only the auth credentials are needed past construction; the rest of
+        // `config` is consumed by the HTTP layer (webhook secret) at startup.
         let token_manager = Arc::new(TokenManager::new(
             config.auth.app_id.clone(),
             config.auth.app_password.clone(),
         ));
         Self {
             id: id.into(),
-            config,
             token_manager,
             running: false,
         }

--- a/src/channels/testchan.rs
+++ b/src/channels/testchan.rs
@@ -20,6 +20,12 @@ pub struct TestChannel {
     running: bool,
 }
 
+/// Shared buffer of messages captured by a [`TestChannel`].
+///
+/// The gateway owns the channel itself (as a `Box<dyn Channel>`), so the HTTP
+/// layer holds one of these handles instead — both point at the same buffer.
+pub type CapturedMessages = Arc<Mutex<Vec<Message>>>;
+
 impl TestChannel {
     pub fn new(id: impl Into<String>) -> Self {
         Self {
@@ -30,13 +36,17 @@ impl TestChannel {
     }
 
     /// Return a cloneable handle to the captured messages store.
-    pub fn captured_handle(&self) -> Arc<Mutex<Vec<Message>>> {
+    ///
+    /// Callers must use this rather than constructing a second `TestChannel`:
+    /// separate instances have separate buffers, so responses written by one
+    /// are invisible to the other.
+    pub fn captured_handle(&self) -> CapturedMessages {
         self.captured.clone()
     }
 
-    /// Drain and return all captured messages (used by the test HTTP endpoint).
-    pub async fn drain_responses(&self) -> Vec<Message> {
-        let mut guard = self.captured.lock().await;
+    /// Drain and return all messages captured so far.
+    pub async fn drain_captured(captured: &CapturedMessages) -> Vec<Message> {
+        let mut guard = captured.lock().await;
         guard.drain(..).collect()
     }
 }

--- a/src/channels/webhook.rs
+++ b/src/channels/webhook.rs
@@ -112,8 +112,7 @@ pub fn parse_webhook_body(
     body: &[u8],
 ) -> Option<Message> {
     let text = if let Some(ref jpath) = endpoint.extract_text {
-        extract_jsonpath(body, jpath)
-            .or_else(|| String::from_utf8(body.to_vec()).ok())
+        extract_jsonpath(body, jpath).or_else(|| String::from_utf8(body.to_vec()).ok())
     } else {
         String::from_utf8(body.to_vec()).ok()
     }?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -112,7 +112,7 @@ impl Default for RateLimitConfig {
 
 // ── Audit logging ─────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AuditConfig {
     /// Enable structured audit logging (env: `AUDIT_ENABLED`).
     #[serde(default)]
@@ -122,15 +122,6 @@ pub struct AuditConfig {
     /// Env: `AUDIT_PATH`.
     #[serde(default)]
     pub path: String,
-}
-
-impl Default for AuditConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            path: String::new(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -448,7 +439,6 @@ pub struct McpServerEntry {
     pub transport: String,
 
     // ── stdio fields ──────────────────────────────────────────────────────────
-
     /// Command to spawn (stdio transport only).
     pub command: Option<String>,
 
@@ -461,7 +451,6 @@ pub struct McpServerEntry {
     pub env: Vec<(String, String)>,
 
     // ── http fields ───────────────────────────────────────────────────────────
-
     /// Base URL of the MCP HTTP server (http transport only).
     pub url: Option<String>,
 }
@@ -1094,7 +1083,12 @@ impl Config {
                     .unwrap_or_else(default_request_timeout_seconds),
                 allowed_ws_origins: std::env::var("GATEWAY_ALLOWED_WS_ORIGINS")
                     .ok()
-                    .map(|s| s.split(',').map(|o| o.trim().to_string()).filter(|o| !o.is_empty()).collect())
+                    .map(|s| {
+                        s.split(',')
+                            .map(|o| o.trim().to_string())
+                            .filter(|o| !o.is_empty())
+                            .collect()
+                    })
                     .unwrap_or_default(),
                 shutdown_timeout_seconds: std::env::var("GATEWAY_SHUTDOWN_TIMEOUT_SECONDS")
                     .ok()

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -35,11 +35,17 @@ impl CronScheduler {
         if let Some(n) = s.strip_suffix('s') {
             n.parse::<u64>().ok().map(std::time::Duration::from_secs)
         } else if let Some(n) = s.strip_suffix('m') {
-            n.parse::<u64>().ok().map(|v| std::time::Duration::from_secs(v * 60))
+            n.parse::<u64>()
+                .ok()
+                .map(|v| std::time::Duration::from_secs(v * 60))
         } else if let Some(n) = s.strip_suffix('h') {
-            n.parse::<u64>().ok().map(|v| std::time::Duration::from_secs(v * 3600))
+            n.parse::<u64>()
+                .ok()
+                .map(|v| std::time::Duration::from_secs(v * 3600))
         } else if let Some(n) = s.strip_suffix('d') {
-            n.parse::<u64>().ok().map(|v| std::time::Duration::from_secs(v * 86400))
+            n.parse::<u64>()
+                .ok()
+                .map(|v| std::time::Duration::from_secs(v * 86400))
         } else {
             None
         }
@@ -139,7 +145,10 @@ mod tests {
             CronScheduler::parse_schedule("1d"),
             Some(std::time::Duration::from_secs(86400))
         );
-        assert_eq!(CronScheduler::parse_schedule("24h"), Some(std::time::Duration::from_secs(86400)));
+        assert_eq!(
+            CronScheduler::parse_schedule("24h"),
+            Some(std::time::Duration::from_secs(86400))
+        );
         assert_eq!(CronScheduler::parse_schedule("invalid"), None);
         assert_eq!(CronScheduler::parse_schedule(""), None);
     }

--- a/src/gateway/deduplicator.rs
+++ b/src/gateway/deduplicator.rs
@@ -68,6 +68,9 @@ mod tests {
         d.seen("u", "b");
         // "a" should have been evicted
         d.seen("u", "c");
-        assert!(!d.seen("u", "a"), "evicted entry should not be detected as duplicate");
+        assert!(
+            !d.seen("u", "a"),
+            "evicted entry should not be detected as duplicate"
+        );
     }
 }

--- a/src/gateway/http.rs
+++ b/src/gateway/http.rs
@@ -6,7 +6,7 @@ use crate::channels::slack::{
 use crate::channels::sms::parse_sms_webhook;
 use crate::channels::teams::{parse_activity, verify_teams_signature, TeamsActivity};
 use crate::channels::telegram::{parse_update, TelegramUpdate};
-use crate::channels::testchan::TestChannel;
+use crate::channels::testchan::{CapturedMessages, TestChannel};
 use crate::channels::webchat::{WebchatSessions, WIDGET_JS};
 use crate::channels::webhook::{parse_webhook_body, verify_webhook_signature};
 use crate::channels::whatsapp::{parse_webhook, WebhookBody};
@@ -14,25 +14,24 @@ use crate::channels::Channel;
 use crate::config::{SkillsConfig, WebhookEndpoint};
 use crate::cron::CronJobStatus;
 use crate::gateway::dashboard::{DashboardEvent, MessageStats};
-use crate::gateway::HotConfig;
 use crate::gateway::rate_limiter::RateLimiter;
 use crate::gateway::user_prefs::UserPreferences;
+use crate::gateway::HotConfig;
 use crate::skills::SkillRegistry;
 use crate::types::Message;
 use axum::{
     body::Bytes,
     error_handling::HandleErrorLayer,
+    extract::Request,
     extract::{
         ws::{Message as WsMessage, WebSocket, WebSocketUpgrade},
         DefaultBodyLimit, Path, Query, State,
     },
     http::{header, HeaderMap, StatusCode},
-    extract::Request,
     middleware::{self, Next},
     response::{IntoResponse, Json, Response},
     routing::{delete, get, post},
-    BoxError,
-    Router,
+    BoxError, Router,
 };
 use prometheus::Encoder;
 use serde::{Deserialize, Serialize};
@@ -77,9 +76,13 @@ pub struct HttpServerConfig {
     /// When `Some(token)`, all API routes (except /live, /ready) require
     /// `Authorization: Bearer <token>`.
     pub api_token: Option<String>,
-    /// When `Some`, the `/test/send` and `/test/responses` endpoints are active
-    /// and backed by this `TestChannel` handle.
-    pub test_channel: Option<Arc<TestChannel>>,
+    /// When `Some`, the `/test/send` and `/test/responses` endpoints are active.
+    /// This is a handle to the *same* buffer the registered `TestChannel` writes
+    /// its captured responses into.
+    pub test_channel: Option<CapturedMessages>,
+    /// Sender used by `POST /test/send` to inject messages into the gateway
+    /// pipeline. Present whenever `test_channel` is set.
+    pub test_tx: Option<mpsc::UnboundedSender<Message>>,
     /// Per-user rate limiter (shared with gateway message loop).
     pub rate_limiter: Arc<RateLimiter>,
     /// Structured audit logger (None when audit is disabled).
@@ -117,7 +120,8 @@ pub struct AppState {
     pub stats: Arc<MessageStats>,
     pub dashboard_expected_auth: Option<String>,
     pub api_token: Option<String>,
-    pub test_channel: Option<Arc<TestChannel>>,
+    pub test_channel: Option<CapturedMessages>,
+    pub test_tx: Option<mpsc::UnboundedSender<Message>>,
     pub rate_limiter: Arc<RateLimiter>,
     pub audit: Option<Arc<AuditLogger>>,
     pub hot_config: Arc<RwLock<HotConfig>>,
@@ -584,7 +588,10 @@ async fn generic_webhook_receive(
 async fn webchat_widget_handler() -> impl IntoResponse {
     (
         StatusCode::OK,
-        [(header::CONTENT_TYPE, "application/javascript; charset=utf-8")],
+        [(
+            header::CONTENT_TYPE,
+            "application/javascript; charset=utf-8",
+        )],
         WIDGET_JS,
     )
 }
@@ -784,31 +791,20 @@ struct TestSendRequest {
     content: String,
 }
 
+/// Inject a message into the gateway pipeline as if it arrived from a real
+/// channel. The agent's reply is captured by the `TestChannel` and retrieved
+/// via `GET /test/responses`.
 async fn test_send_handler(
     State(state): State<AppState>,
     Json(body): Json<TestSendRequest>,
 ) -> impl IntoResponse {
-    let tx = match &state.teams_tx.as_ref().or(
-        // We reuse the test_channel for routing — find the testchan sender via message_tx path
-        // The test channel inject is handled via the general message_tx stored in state
-        None.as_ref(),
-    ) {
-        _ => &None::<mpsc::UnboundedSender<Message>>,
+    let tx = match state.test_tx.as_ref() {
+        Some(tx) => tx,
+        None => {
+            return (StatusCode::NOT_FOUND, "test channel not enabled").into_response();
+        }
     };
-    let _ = tx; // handled below via test_channel directly
 
-    // Inject via the testchan — but we need a message_tx here.
-    // For test injection, we push directly through a dedicated sender if available.
-    // We expose a test_message_tx on AppState for this purpose.
-    if state.test_channel.is_none() {
-        return (
-            StatusCode::NOT_FOUND,
-            "test channel not enabled",
-        )
-            .into_response();
-    }
-
-    // Test injection: create a message and send via test_message_tx
     let msg = Message::new(
         "testchan-main".to_string(),
         body.user_id,
@@ -816,25 +812,27 @@ async fn test_send_handler(
         body.content,
     );
 
-    // Store in the channel's captured list — responses come back via send_message
-    // For actual routing, we need the gateway's message_tx.
-    // This is wired up in gateway/mod.rs via test_message_tx.
-    if let Some(ref _tc) = state.test_channel {
-        // The gateway wires a dedicated sender for test injection
-        // For now, return 200 to indicate the endpoint is available
-        return (StatusCode::OK, Json(serde_json::json!({"status": "queued", "message": format!("{:?}", msg.content)}))).into_response();
+    if let Err(e) = tx.send(msg) {
+        warn!("Failed to enqueue test message: {}", e);
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "gateway not accepting messages",
+        )
+            .into_response();
     }
 
-    StatusCode::OK.into_response()
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({"status": "queued"})),
+    )
+        .into_response()
 }
 
-async fn test_responses_handler(
-    State(state): State<AppState>,
-) -> impl IntoResponse {
+async fn test_responses_handler(State(state): State<AppState>) -> impl IntoResponse {
     match &state.test_channel {
         None => (StatusCode::NOT_FOUND, "test channel not enabled").into_response(),
-        Some(tc) => {
-            let responses = tc.drain_responses().await;
+        Some(captured) => {
+            let responses = TestChannel::drain_captured(captured).await;
             let json: Vec<serde_json::Value> = responses
                 .iter()
                 .map(|m| {
@@ -1029,8 +1027,12 @@ async fn cron_jobs_handler(State(state): State<AppState>) -> impl IntoResponse {
 
 // ── Router ────────────────────────────────────────────────────────────────────
 
-pub fn create_router(state: AppState, max_body_bytes: usize, request_timeout_seconds: u64) -> Router {
-    let router = Router::new()
+pub fn create_router(
+    state: AppState,
+    max_body_bytes: usize,
+    request_timeout_seconds: u64,
+) -> Router {
+    Router::new()
         // Health / observability
         .route("/health", get(health_handler))
         .route("/status", get(status_handler))
@@ -1098,12 +1100,12 @@ pub fn create_router(state: AppState, max_body_bytes: usize, request_timeout_sec
                 .layer(HandleErrorLayer::new(|_: BoxError| async {
                     StatusCode::REQUEST_TIMEOUT
                 }))
-                .layer(TimeoutLayer::new(Duration::from_secs(request_timeout_seconds))),
+                .layer(TimeoutLayer::new(Duration::from_secs(
+                    request_timeout_seconds,
+                ))),
         )
         .layer(DefaultBodyLimit::max(max_body_bytes))
-        .with_state(state);
-
-    router
+        .with_state(state)
 }
 
 pub async fn start_http_server(cfg: HttpServerConfig) -> anyhow::Result<()> {
@@ -1132,6 +1134,7 @@ pub async fn start_http_server(cfg: HttpServerConfig) -> anyhow::Result<()> {
         dashboard_expected_auth: cfg.dashboard_expected_auth,
         api_token: cfg.api_token,
         test_channel: cfg.test_channel,
+        test_tx: cfg.test_tx,
         rate_limiter: cfg.rate_limiter,
         audit: cfg.audit,
         hot_config: cfg.hot_config,
@@ -1153,9 +1156,18 @@ pub async fn start_http_server(cfg: HttpServerConfig) -> anyhow::Result<()> {
     info!("  Live:       http://localhost:{}/live", cfg.port);
     info!("  Dashboard:  http://localhost:{}/dashboard", cfg.port);
     info!("  Dash WS:    ws://localhost:{}/dashboard/ws", cfg.port);
-    info!("  Webchat:    ws://localhost:{}/channels/webchat/ws", cfg.port);
-    info!("  Widget JS:  http://localhost:{}/channels/webchat/widget.js", cfg.port);
-    info!("  Admin:      http://localhost:{}/admin/channels/health", cfg.port);
+    info!(
+        "  Webchat:    ws://localhost:{}/channels/webchat/ws",
+        cfg.port
+    );
+    info!(
+        "  Widget JS:  http://localhost:{}/channels/webchat/widget.js",
+        cfg.port
+    );
+    info!(
+        "  Admin:      http://localhost:{}/admin/channels/health",
+        cfg.port
+    );
     info!("  Cron jobs:  http://localhost:{}/cron/jobs", cfg.port);
 
     axum::serve(listener, app).await?;
@@ -1197,6 +1209,7 @@ mod tests {
             dashboard_expected_auth: None,
             api_token: None,
             test_channel: None,
+            test_tx: None,
             rate_limiter: RateLimiter::new(),
             audit: None,
             hot_config: Arc::new(RwLock::new(HotConfig {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -18,7 +18,7 @@ use crate::gateway::deduplicator::MessageDeduplicator;
 use crate::gateway::formatter::ResponseFormatter;
 use crate::gateway::rate_limiter::RateLimiter;
 use crate::memory::{
-    InMemoryStore, MemorySummarizer, MemoryStore, PostgresStore, RedisStore, SqliteStore,
+    InMemoryStore, MemoryStore, MemorySummarizer, PostgresStore, RedisStore, SqliteStore,
     VectorMemoryStore,
 };
 use crate::skills::SkillRegistry;
@@ -30,7 +30,7 @@ use tokio::sync::{broadcast, mpsc, Mutex, RwLock};
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn, Instrument};
 
-use agenkit::protocols::{McpClient, McpHttpClient, McpStdioClient, mcp_tools_from_client};
+use agenkit::protocols::{mcp_tools_from_client, McpClient, McpHttpClient, McpStdioClient};
 use agenkit::Tool;
 use user_prefs::UserPreferences;
 
@@ -139,33 +139,31 @@ impl Gateway {
 
         // Select memory backend based on config
         let memory: Arc<dyn MemoryStore> = match config.memory.backend.as_str() {
-            "redis" => {
-                match &config.memory.redis_url {
-                    Some(url) => {
-                        match RedisStore::new(
-                            url,
-                            config.agents.max_history,
-                            config.memory.redis_ttl_seconds,
-                        ) {
-                            Ok(store) => {
-                                info!("Using Redis memory store (url={})", url);
-                                Arc::new(store)
-                            }
-                            Err(e) => {
-                                error!(
-                                    "Failed to create Redis store, falling back to in-memory: {}",
-                                    e
-                                );
-                                Arc::new(InMemoryStore::new(config.agents.max_history))
-                            }
+            "redis" => match &config.memory.redis_url {
+                Some(url) => {
+                    match RedisStore::new(
+                        url,
+                        config.agents.max_history,
+                        config.memory.redis_ttl_seconds,
+                    ) {
+                        Ok(store) => {
+                            info!("Using Redis memory store (url={})", url);
+                            Arc::new(store)
+                        }
+                        Err(e) => {
+                            error!(
+                                "Failed to create Redis store, falling back to in-memory: {}",
+                                e
+                            );
+                            Arc::new(InMemoryStore::new(config.agents.max_history))
                         }
                     }
-                    None => {
-                        error!("memory.backend=redis but REDIS_URL not set; falling back to in-memory");
-                        Arc::new(InMemoryStore::new(config.agents.max_history))
-                    }
                 }
-            }
+                None => {
+                    error!("memory.backend=redis but REDIS_URL not set; falling back to in-memory");
+                    Arc::new(InMemoryStore::new(config.agents.max_history))
+                }
+            },
             "sqlite" => {
                 let path = config
                     .memory
@@ -184,31 +182,33 @@ impl Gateway {
                         Arc::new(store)
                     }
                     Err(e) => {
-                        error!("Failed to create SQLite store, falling back to in-memory: {}", e);
+                        error!(
+                            "Failed to create SQLite store, falling back to in-memory: {}",
+                            e
+                        );
                         Arc::new(InMemoryStore::new(config.agents.max_history))
                     }
                 }
             }
-            "postgres" => {
-                match &config.memory.postgres_url {
-                    Some(url) => {
-                        match PostgresStore::new(url, config.agents.max_history) {
-                            Ok(store) => {
-                                info!("Using PostgreSQL memory store");
-                                Arc::new(store)
-                            }
-                            Err(e) => {
-                                error!("Failed to create Postgres store, falling back to in-memory: {}", e);
-                                Arc::new(InMemoryStore::new(config.agents.max_history))
-                            }
-                        }
+            "postgres" => match &config.memory.postgres_url {
+                Some(url) => match PostgresStore::new(url, config.agents.max_history) {
+                    Ok(store) => {
+                        info!("Using PostgreSQL memory store");
+                        Arc::new(store)
                     }
-                    None => {
-                        error!("memory.backend=postgres but DATABASE_URL not set; falling back to in-memory");
+                    Err(e) => {
+                        error!(
+                            "Failed to create Postgres store, falling back to in-memory: {}",
+                            e
+                        );
                         Arc::new(InMemoryStore::new(config.agents.max_history))
                     }
+                },
+                None => {
+                    error!("memory.backend=postgres but DATABASE_URL not set; falling back to in-memory");
+                    Arc::new(InMemoryStore::new(config.agents.max_history))
                 }
-            }
+            },
             "vector" => {
                 match VectorMemoryStore::with_decay(
                     config.agents.max_history,
@@ -219,22 +219,22 @@ impl Gateway {
                         Arc::new(store)
                     }
                     Err(e) => {
-                        error!("Failed to create vector store, falling back to in-memory: {}", e);
+                        error!(
+                            "Failed to create vector store, falling back to in-memory: {}",
+                            e
+                        );
                         Arc::new(InMemoryStore::new(config.agents.max_history))
                     }
                 }
             }
-            _ => {
-                Arc::new(InMemoryStore::new(config.agents.max_history))
-            }
+            _ => Arc::new(InMemoryStore::new(config.agents.max_history)),
         };
 
         // Build summarizer if enabled
         let summarizer = if config.memory.summarization.enabled {
             info!(
                 "Memory summarization enabled (trigger_at={}, keep_recent={})",
-                config.memory.summarization.trigger_at,
-                config.memory.summarization.keep_recent
+                config.memory.summarization.trigger_at, config.memory.summarization.keep_recent
             );
             Some(Arc::new(MemorySummarizer::new(
                 config.memory.summarization.clone(),
@@ -536,8 +536,7 @@ impl Gateway {
         // Add SMS channel if enabled (webhook-based, routes handled by HTTP)
         if let Some(sms_config) = self.config.channels.sms.clone().filter(|c| c.enabled) {
             info!("Setting up SMS channel (Twilio webhook mode)");
-            let sms =
-                crate::channels::sms::SmsChannel::new("sms-main".to_string(), sms_config);
+            let sms = crate::channels::sms::SmsChannel::new("sms-main".to_string(), sms_config);
             self.register_channel(Box::new(sms)).await;
         }
 
@@ -555,18 +554,19 @@ impl Gateway {
         }
 
         // Add Webchat channel if enabled
-        let webchat_sessions = if let Some(wc_config) =
-            self.config.channels.webchat.clone().filter(|c| c.enabled)
-        {
-            info!("Setting up webchat channel");
-            let wc =
-                crate::channels::webchat::WebchatChannel::new("webchat-main".to_string(), wc_config);
-            let sessions = wc.sessions_handle();
-            self.register_channel(Box::new(wc)).await;
-            Some(sessions)
-        } else {
-            None
-        };
+        let webchat_sessions =
+            if let Some(wc_config) = self.config.channels.webchat.clone().filter(|c| c.enabled) {
+                info!("Setting up webchat channel");
+                let wc = crate::channels::webchat::WebchatChannel::new(
+                    "webchat-main".to_string(),
+                    wc_config,
+                );
+                let sessions = wc.sessions_handle();
+                self.register_channel(Box::new(wc)).await;
+                Some(sessions)
+            } else {
+                None
+            };
 
         // Add Email channel if enabled
         if let Some(em_config) = self.config.channels.email.clone().filter(|c| c.enabled) {
@@ -582,24 +582,22 @@ impl Gateway {
         // Add Microsoft Teams channel if enabled
         if let Some(teams_config) = self.config.channels.teams.clone().filter(|c| c.enabled) {
             info!("Setting up Microsoft Teams channel (webhook mode)");
-            let teams = crate::channels::teams::TeamsChannel::new(
-                "teams-main".to_string(),
-                teams_config,
-            );
+            let teams =
+                crate::channels::teams::TeamsChannel::new("teams-main".to_string(), teams_config);
             self.register_channel(Box::new(teams)).await;
         }
 
-        // Add test channel if enabled
+        // Add test channel if enabled.
+        //
+        // The gateway owns the channel; the HTTP layer gets a handle to the same
+        // captured-message buffer. Constructing a second `TestChannel` here would
+        // give HTTP a buffer nothing ever writes to.
         let test_channel_handle = if self.config.channels.test_channel {
             info!("Setting up zero-credential test channel (POST /test/send, GET /test/responses)");
-            let handle = Arc::new(
-                crate::channels::testchan::TestChannel::new("testchan-main".to_string())
-            );
-            let _ = crate::channels::testchan::TestChannel::new("testchan-main".to_string());
-            self.register_channel(Box::new(
-                crate::channels::testchan::TestChannel::new("testchan-main".to_string())
-            )).await;
-            Some(handle)
+            let channel = crate::channels::testchan::TestChannel::new("testchan-main".to_string());
+            let captured = channel.captured_handle();
+            self.register_channel(Box::new(channel)).await;
+            Some(captured)
         } else {
             None
         };
@@ -629,12 +627,18 @@ impl Gateway {
                             mcp_tools_from_client(std::sync::Arc::new(client))
                                 .await
                                 .unwrap_or_else(|e| {
-                                    error!("Failed to list tools from MCP server '{}': {}", server_cfg.name, e);
+                                    error!(
+                                        "Failed to list tools from MCP server '{}': {}",
+                                        server_cfg.name, e
+                                    );
                                     vec![]
                                 })
                         }
                         Err(e) => {
-                            error!("Failed to initialize MCP server '{}': {}", server_cfg.name, e);
+                            error!(
+                                "Failed to initialize MCP server '{}': {}",
+                                server_cfg.name, e
+                            );
                             continue;
                         }
                     }
@@ -666,12 +670,18 @@ impl Gateway {
                             mcp_tools_from_client(std::sync::Arc::new(client))
                                 .await
                                 .unwrap_or_else(|e| {
-                                    error!("Failed to list tools from MCP server '{}': {}", server_cfg.name, e);
+                                    error!(
+                                        "Failed to list tools from MCP server '{}': {}",
+                                        server_cfg.name, e
+                                    );
                                     vec![]
                                 })
                         }
                         Err(e) => {
-                            error!("Failed to initialize MCP server '{}': {}", server_cfg.name, e);
+                            error!(
+                                "Failed to initialize MCP server '{}': {}",
+                                server_cfg.name, e
+                            );
                             continue;
                         }
                     }
@@ -765,9 +775,7 @@ impl Gateway {
             None
         };
 
-        let webchat_tx = webchat_sessions
-            .as_ref()
-            .map(|_| self.message_tx.clone());
+        let webchat_tx = webchat_sessions.as_ref().map(|_| self.message_tx.clone());
 
         let teams_tx = self
             .config
@@ -812,13 +820,20 @@ impl Gateway {
             webchat_sessions,
             webchat_tx,
             teams_tx,
-            teams_hmac_secret: self.config.channels.teams.as_ref()
+            teams_hmac_secret: self
+                .config
+                .channels
+                .teams
+                .as_ref()
                 .map(|t| t.auth.hmac_secret.clone())
                 .unwrap_or_default(),
             user_prefs: self.user_prefs.clone(),
             stats: self.stats.clone(),
             dashboard_expected_auth,
             api_token: self.config.gateway.api_token.clone(),
+            test_tx: test_channel_handle
+                .as_ref()
+                .map(|_| self.message_tx.clone()),
             test_channel: test_channel_handle,
             rate_limiter: self.rate_limiter.clone(),
             audit: self.audit.clone(),
@@ -1035,10 +1050,7 @@ async fn handle_message_inner(
     // ── Deduplication ─────────────────────────────────────────────────────────
     if let Some(ref dedup) = deduplicator {
         if dedup.lock().await.seen(&message.user_id, &message.content) {
-            tracing::debug!(
-                "Duplicate message from '{}', dropping",
-                message.user_id
-            );
+            tracing::debug!("Duplicate message from '{}', dropping", message.user_id);
             return Ok(());
         }
     }
@@ -1072,8 +1084,7 @@ async fn handle_message_inner(
                 message.channel_id.clone(),
                 "assistant".to_string(),
                 "RustyNail".to_string(),
-                "⚠️ Rate limit exceeded. Please wait before sending another message."
-                    .to_string(),
+                "⚠️ Rate limit exceeded. Please wait before sending another message.".to_string(),
             );
             let channels = channels.read().await;
             for channel in channels.iter() {

--- a/src/gateway/openai_compat.rs
+++ b/src/gateway/openai_compat.rs
@@ -207,10 +207,14 @@ pub async fn openai_chat_completions(
             .into_response()
     } else {
         // Non-streaming path
-        match state.agent_manager.process_message(&user_id, &content).await {
+        match state
+            .agent_manager
+            .process_message(&user_id, &content)
+            .await
+        {
             Ok(text) => {
-                let prompt_tokens = (content.len() + 3) / 4;
-                let completion_tokens = (text.len() + 3) / 4;
+                let prompt_tokens = content.len().div_ceil(4);
+                let completion_tokens = text.len().div_ceil(4);
                 let resp = ChatCompletionResponse {
                     id: completion_id,
                     object: "chat.completion".to_string(),
@@ -284,6 +288,7 @@ mod tests {
             dashboard_expected_auth: None,
             api_token: None,
             test_channel: None,
+            test_tx: None,
             rate_limiter: RateLimiter::new(),
             audit: None,
             hot_config: Arc::new(RwLock::new(HotConfig {
@@ -324,7 +329,11 @@ mod tests {
             .get("content-type")
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
-        assert!(ct.contains("json"), "expected json content-type, got: {}", ct);
+        assert!(
+            ct.contains("json"),
+            "expected json content-type, got: {}",
+            ct
+        );
     }
 
     #[tokio::test]

--- a/src/gateway/rate_limiter.rs
+++ b/src/gateway/rate_limiter.rs
@@ -100,7 +100,7 @@ mod tests {
         assert!(rl.check_and_record("user1", &c)); // 1
         assert!(rl.check_and_record("user1", &c)); // 2
         assert!(rl.check_and_record("user1", &c)); // 3 — hits the limit
-        // 4th message should be blocked
+                                                   // 4th message should be blocked
         assert!(!rl.check_and_record("user1", &c));
     }
 
@@ -110,8 +110,8 @@ mod tests {
         // window_seconds = 0 means the window expires immediately after each call
         let c = cfg(true, 2, 0);
         assert!(rl.check_and_record("user1", &c)); // 1st call — resets window, count = 1
-        // With window_seconds=0, elapsed() >= Duration::ZERO is always true,
-        // so the next call resets and allows.
+                                                   // With window_seconds=0, elapsed() >= Duration::ZERO is always true,
+                                                   // so the next call resets and allows.
         assert!(rl.check_and_record("user1", &c)); // window expired → reset, count = 1
         assert!(rl.check_and_record("user1", &c)); // window expired → reset, count = 1
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,8 +273,7 @@ fn cmd_config_check() -> Result<()> {
         if config.memory.summarization.enabled {
             format!(
                 "enabled (trigger_at={}, keep_recent={})",
-                config.memory.summarization.trigger_at,
-                config.memory.summarization.keep_recent
+                config.memory.summarization.trigger_at, config.memory.summarization.keep_recent
             )
         } else {
             "disabled".to_string()
@@ -385,17 +384,22 @@ fn cmd_config_check() -> Result<()> {
         "  Shutdown timeout: {}s",
         config.gateway.shutdown_timeout_seconds
     );
-    println!(
-        "  Cron jobs:        {}",
-        config.cron.jobs.len()
-    );
+    println!("  Cron jobs:        {}", config.cron.jobs.len());
     println!(
         "  PDF tool:         {}",
-        if config.tools.pdf_enabled { "enabled" } else { "disabled" }
+        if config.tools.pdf_enabled {
+            "enabled"
+        } else {
+            "disabled"
+        }
     );
     println!(
         "  Image tool:       {}",
-        if config.tools.image_enabled { "enabled" } else { "disabled" }
+        if config.tools.image_enabled {
+            "enabled"
+        } else {
+            "disabled"
+        }
     );
 
     Ok(())
@@ -412,8 +416,7 @@ fn cmd_config_validate() -> Result<()> {
     // ── Check 1: config loads ─────────────────────────────────────────────────
     let config = match Config::load() {
         Ok(cfg) => {
-            let source = std::env::var("CONFIG_FILE")
-                .unwrap_or_else(|_| "(env vars)".to_string());
+            let source = std::env::var("CONFIG_FILE").unwrap_or_else(|_| "(env vars)".to_string());
             println!("[✓] Config loaded ({})", source);
             cfg
         }
@@ -437,7 +440,13 @@ fn cmd_config_validate() -> Result<()> {
     // ── Check 3: memory backend dependencies ─────────────────────────────────
     match config.memory.backend.as_str() {
         "redis" => {
-            if config.memory.redis_url.as_deref().map(|u| u.is_empty()).unwrap_or(true) {
+            if config
+                .memory
+                .redis_url
+                .as_deref()
+                .map(|u| u.is_empty())
+                .unwrap_or(true)
+            {
                 println!("[✗] Memory backend is redis but memory.redis_url is not set");
                 failures += 1;
             } else {
@@ -445,7 +454,13 @@ fn cmd_config_validate() -> Result<()> {
             }
         }
         "sqlite" => {
-            if config.memory.sqlite_path.as_deref().map(|p| p.is_empty()).unwrap_or(true) {
+            if config
+                .memory
+                .sqlite_path
+                .as_deref()
+                .map(|p| p.is_empty())
+                .unwrap_or(true)
+            {
                 println!("[✗] Memory backend is sqlite but memory.sqlite_path is not set");
                 failures += 1;
             } else {
@@ -453,7 +468,13 @@ fn cmd_config_validate() -> Result<()> {
             }
         }
         "postgres" => {
-            if config.memory.postgres_url.as_deref().map(|u| u.is_empty()).unwrap_or(true) {
+            if config
+                .memory
+                .postgres_url
+                .as_deref()
+                .map(|u| u.is_empty())
+                .unwrap_or(true)
+            {
                 println!("[✗] Memory backend is postgres but memory.postgres_url is not set");
                 failures += 1;
             } else {
@@ -477,7 +498,12 @@ fn cmd_config_validate() -> Result<()> {
 
 /// `rustynail completions <shell>` — print shell completion script.
 fn cmd_completions(shell: Shell) -> Result<()> {
-    clap_complete::generate(shell, &mut Cli::command(), "rustynail", &mut std::io::stdout());
+    clap_complete::generate(
+        shell,
+        &mut Cli::command(),
+        "rustynail",
+        &mut std::io::stdout(),
+    );
     Ok(())
 }
 
@@ -494,10 +520,8 @@ async fn cmd_mcp_serve() -> Result<()> {
 
     let config = Config::load()?;
 
-    let mut tools: Vec<Arc<dyn agenkit::Tool>> = vec![
-        Arc::new(CalculatorTool),
-        Arc::new(FormatterTool),
-    ];
+    let mut tools: Vec<Arc<dyn agenkit::Tool>> =
+        vec![Arc::new(CalculatorTool), Arc::new(FormatterTool)];
 
     if config.tools.enabled {
         if let Some(ref fs_root) = config.tools.filesystem_root {

--- a/src/memory/postgres.rs
+++ b/src/memory/postgres.rs
@@ -126,14 +126,11 @@ impl MemoryStore for PostgresStore {
         let pool = self.pool.clone();
         let uid = user_id.to_string();
 
-        if let Err(e) = self
-            .rt
-            .block_on(
-                sqlx::query("DELETE FROM rustynail_messages WHERE user_id = $1")
-                    .bind(&uid)
-                    .execute(&pool),
-            )
-        {
+        if let Err(e) = self.rt.block_on(
+            sqlx::query("DELETE FROM rustynail_messages WHERE user_id = $1")
+                .bind(&uid)
+                .execute(&pool),
+        ) {
             error!("Postgres clear_history error: {}", e);
         }
     }

--- a/src/memory/sqlite.rs
+++ b/src/memory/sqlite.rs
@@ -135,12 +135,11 @@ impl MemoryStore for SqliteStore {
         let pool = self.pool.clone();
         let uid = user_id.to_string();
 
-        if let Err(e) = self
-            .rt
-            .block_on(sqlx::query("DELETE FROM messages WHERE user_id = ?")
+        if let Err(e) = self.rt.block_on(
+            sqlx::query("DELETE FROM messages WHERE user_id = ?")
                 .bind(&uid)
-                .execute(&pool))
-        {
+                .execute(&pool),
+        ) {
             error!("SQLite clear_history error: {}", e);
         }
     }

--- a/src/memory/summarizer.rs
+++ b/src/memory/summarizer.rs
@@ -7,7 +7,7 @@ use tracing::{error, info};
 
 /// Rough token estimator: 1 token ≈ 4 bytes (allocation-free, no external deps).
 fn estimate_tokens(text: &str) -> usize {
-    (text.len() + 3) / 4
+    text.len().div_ceil(4)
 }
 
 /// Summarises old conversation history when it grows beyond a threshold,
@@ -88,7 +88,10 @@ impl MemorySummarizer {
                     for msg in keep_recent {
                         store.add_message(&uid, msg);
                     }
-                    info!("Summarised history for user {} ({} messages condensed)", uid, to_summarize_count);
+                    info!(
+                        "Summarised history for user {} ({} messages condensed)",
+                        uid, to_summarize_count
+                    );
                 }
                 Err(e) => {
                     error!("Summarisation error for user {}: {}", uid, e);
@@ -137,13 +140,20 @@ mod tests {
         assert_eq!(history.len(), 5, "pre-summarize, 5 messages");
 
         let total_tokens: usize = history.iter().map(|m| estimate_tokens(m)).sum();
-        assert!(total_tokens > 10, "total tokens {} should exceed budget 10", total_tokens);
+        assert!(
+            total_tokens > 10,
+            "total tokens {} should exceed budget 10",
+            total_tokens
+        );
 
         // Verify the token trigger condition would fire (count_trigger=false, token_trigger=true)
         let count_trigger = history.len() > 100;
         let token_trigger = total_tokens > 10;
         assert!(!count_trigger, "count trigger must not fire");
-        assert!(token_trigger, "token trigger must fire before count threshold");
+        assert!(
+            token_trigger,
+            "token trigger must fire before count threshold"
+        );
 
         // maybe_summarize spawns a tokio task; call it to verify no panic
         summarizer.maybe_summarize(store, "u1");

--- a/src/memory/vector.rs
+++ b/src/memory/vector.rs
@@ -1,6 +1,6 @@
 use crate::memory::MemoryStore;
-use agenkit::memory::vector_memory::{EmbeddingProvider, InMemoryVectorStore, VectorMemory};
 use agenkit::core::AgentError;
+use agenkit::memory::vector_memory::{EmbeddingProvider, InMemoryVectorStore, VectorMemory};
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -62,12 +62,15 @@ fn recency_weight(half_life_secs: f64, age_secs: f64) -> f64 {
 /// messages without a semantic query). When `decay_half_life_seconds > 0` messages
 /// are returned sorted by recency weight (most recent first).
 ///
+/// Per-user ring buffer of `(message, arrival time)` pairs.
+type RingBuffer = Arc<RwLock<HashMap<String, Vec<(String, DateTime<Utc>)>>>>;
+
 /// All async agenkit operations run on a dedicated tokio runtime.
 pub struct VectorMemoryStore {
     rt: Arc<tokio::runtime::Runtime>,
     vector_memory: Arc<VectorMemory>,
     /// Secondary ring buffer: ordered recent messages with timestamps per user.
-    ring: Arc<RwLock<HashMap<String, Vec<(String, DateTime<Utc>)>>>>,
+    ring: RingBuffer,
     max_history: usize,
     /// Exponential decay half-life in seconds. 0 = no decay.
     decay_half_life_seconds: f64,
@@ -87,7 +90,10 @@ impl VectorMemoryStore {
         let store = Box::new(InMemoryVectorStore::new());
         let vector_memory = Arc::new(VectorMemory::new(embeddings, Some(store)));
 
-        info!("Vector memory store initialised (in-process, simple embeddings, half_life={}s)", decay_half_life_seconds);
+        info!(
+            "Vector memory store initialised (in-process, simple embeddings, half_life={}s)",
+            decay_half_life_seconds
+        );
         Ok(Self {
             rt: Arc::new(rt),
             vector_memory,
@@ -144,7 +150,9 @@ impl MemoryStore for VectorMemoryStore {
         let msg = message.clone();
         if let Err(e) = self.rt.block_on(async move {
             let agenkit_msg = agenkit::core::Message::with_text("user", &msg);
-            vm.store(&uid, agenkit_msg, None).await.map_err(|e| anyhow::anyhow!("{}", e))
+            vm.store(&uid, agenkit_msg, None)
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))
         }) {
             error!("VectorMemory store error: {}", e);
         }
@@ -179,7 +187,11 @@ mod tests {
     fn test_recency_weight_at_half_life() {
         let w = recency_weight(3600.0, 3600.0);
         // At exactly the half-life, weight should be ≈ 0.5
-        assert!((w - 0.5).abs() < 1e-6, "expected ≈0.5 at half-life, got {}", w);
+        assert!(
+            (w - 0.5).abs() < 1e-6,
+            "expected ≈0.5 at half-life, got {}",
+            w
+        );
     }
 
     #[test]

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -103,9 +103,7 @@ impl SkillRegistry {
             return None;
         }
         let selected = &self.skills[..self.skills.len().min(max_active)];
-        let mut parts = vec![
-            "\n\n--- Skills / Behavioral Guidance ---".to_string(),
-        ];
+        let mut parts = vec!["\n\n--- Skills / Behavioral Guidance ---".to_string()];
         for skill in selected {
             parts.push(format!("\n## {}\n{}", skill.name, skill.content));
         }

--- a/src/tools/image.rs
+++ b/src/tools/image.rs
@@ -112,51 +112,49 @@ impl Tool for ImageAnalysisTool {
             .unwrap_or(DEFAULT_MAX_BYTES);
 
         // Fetch bytes + detect media type
-        let (bytes, media_type) =
-            if source.starts_with("http://") || source.starts_with("https://") {
-                let client = reqwest::Client::builder()
-                    .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
-                    .build()
-                    .map_err(|e| {
-                        AgentError::Internal(format!("failed to build HTTP client: {}", e))
-                    })?;
+        let (bytes, media_type) = if source.starts_with("http://") || source.starts_with("https://")
+        {
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+                .build()
+                .map_err(|e| AgentError::Internal(format!("failed to build HTTP client: {}", e)))?;
 
-                let response = client
-                    .get(&source)
-                    .send()
-                    .await
-                    .map_err(|e| AgentError::Internal(format!("fetch error: {}", e)))?;
+            let response = client
+                .get(&source)
+                .send()
+                .await
+                .map_err(|e| AgentError::Internal(format!("fetch error: {}", e)))?;
 
-                if !response.status().is_success() {
-                    return Ok(ToolResult::error(format!(
-                        "HTTP {} for {}",
-                        response.status(),
-                        source
-                    )));
-                }
+            if !response.status().is_success() {
+                return Ok(ToolResult::error(format!(
+                    "HTTP {} for {}",
+                    response.status(),
+                    source
+                )));
+            }
 
-                let ct = response
-                    .headers()
-                    .get(reqwest::header::CONTENT_TYPE)
-                    .and_then(|v| v.to_str().ok())
-                    .map(|s| s.to_string());
+            let ct = response
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
 
-                let mt = detect_media_type(&source, ct.as_deref());
+            let mt = detect_media_type(&source, ct.as_deref());
 
-                let data = response
-                    .bytes()
-                    .await
-                    .map_err(|e| AgentError::Internal(format!("read error: {}", e)))?
-                    .to_vec();
+            let data = response
+                .bytes()
+                .await
+                .map_err(|e| AgentError::Internal(format!("read error: {}", e)))?
+                .to_vec();
 
-                (data, mt)
-            } else {
-                let data = tokio::fs::read(&source)
-                    .await
-                    .map_err(|e| AgentError::Internal(format!("file read error: {}", e)))?;
-                let mt = detect_media_type(&source, None);
-                (data, mt)
-            };
+            (data, mt)
+        } else {
+            let data = tokio::fs::read(&source)
+                .await
+                .map_err(|e| AgentError::Internal(format!("file read error: {}", e)))?;
+            let mt = detect_media_type(&source, None);
+            (data, mt)
+        };
 
         let media_type = match media_type {
             Some(mt) => mt,

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -6,12 +6,26 @@ use tokio::time::timeout;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
+/// Shell metacharacters rejected while an allowlist is active.
+///
+/// An allowlisted command is exec'd directly rather than through `sh -c`, so
+/// these characters no longer carry meaning. Rejecting them outright — instead
+/// of passing them through as literal argv bytes — means a caller attempting
+/// `git status; rm -rf ~` gets a clear error rather than a puzzling one.
+const SHELL_METACHARS: &[char] = &[';', '|', '&', '$', '`', '>', '<', '\n', '\r'];
+
 /// Shell configuration injected at construction time.
 #[derive(Clone, Debug)]
 pub struct ShellToolConfig {
     /// Whether to require user approval before executing (default: true).
     pub require_approval: bool,
-    /// If non-empty, commands must match one of these prefixes.
+    /// If non-empty, restricts execution to these commands.
+    ///
+    /// Entries are matched token-wise against the parsed argv, not as raw
+    /// string prefixes: `git` permits any git invocation, while `git status`
+    /// permits only that subcommand. A non-empty allowlist also switches
+    /// execution from `sh -c` to a direct exec, so shell features
+    /// (pipes, redirection, substitution, globbing) are unavailable.
     pub allowed_commands: Vec<String>,
 }
 
@@ -22,6 +36,62 @@ impl Default for ShellToolConfig {
             allowed_commands: Vec::new(),
         }
     }
+}
+
+/// Split a command into argv, honouring single and double quotes.
+///
+/// Deliberately not a shell parser: quotes group arguments containing spaces,
+/// and nothing else is interpreted. Callers reject metacharacters before this
+/// runs, so there is no expansion, substitution, or operator handling to do.
+fn tokenize(command: &str) -> Result<Vec<String>, String> {
+    let mut argv = Vec::new();
+    let mut current = String::new();
+    let mut has_token = false;
+    let mut quote: Option<char> = None;
+
+    for ch in command.chars() {
+        match quote {
+            Some(q) if ch == q => quote = None,
+            Some(_) => current.push(ch),
+            None if ch == '\'' || ch == '"' => {
+                quote = Some(ch);
+                has_token = true;
+            }
+            None if ch.is_whitespace() => {
+                if has_token {
+                    argv.push(std::mem::take(&mut current));
+                    has_token = false;
+                }
+            }
+            None => {
+                current.push(ch);
+                has_token = true;
+            }
+        }
+    }
+
+    if quote.is_some() {
+        return Err("unterminated quote".to_string());
+    }
+    if has_token {
+        argv.push(current);
+    }
+    Ok(argv)
+}
+
+/// Whether `argv` is permitted by `allowlist`.
+///
+/// Each entry is tokenized and compared element-wise against the head of
+/// `argv`, so an entry constrains the program and any leading subcommands it
+/// names while leaving later arguments free.
+fn is_allowed(argv: &[String], allowlist: &[String]) -> bool {
+    allowlist.iter().any(|entry| {
+        let expected = match tokenize(entry) {
+            Ok(t) if !t.is_empty() => t,
+            _ => return false,
+        };
+        argv.len() >= expected.len() && argv[..expected.len()] == expected[..]
+    })
 }
 
 pub struct ShellTool {
@@ -102,6 +172,44 @@ impl Tool for ShellTool {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
+        // Allowlist check runs before the approval gate so a command that can
+        // never execute is rejected outright rather than queued for approval.
+        //
+        // With an allowlist active the command is exec'd directly, so it must
+        // be a single program invocation: metacharacters are rejected rather
+        // than silently passed through as literal argv.
+        let argv = if self.config.allowed_commands.is_empty() {
+            None
+        } else {
+            if let Some(bad) = command.chars().find(|c| SHELL_METACHARS.contains(c)) {
+                return Ok(ToolResult::error(format!(
+                    "Command contains shell metacharacter {:?}, which is not permitted \
+                     when an allowlist is configured: `{}`",
+                    bad, command
+                )));
+            }
+
+            let argv = match tokenize(&command) {
+                Ok(a) => a,
+                Err(e) => {
+                    return Ok(ToolResult::error(format!(
+                        "Could not parse command ({}): `{}`",
+                        e, command
+                    )))
+                }
+            };
+            if argv.is_empty() {
+                return Ok(ToolResult::error("command is empty"));
+            }
+            if !is_allowed(&argv, &self.config.allowed_commands) {
+                return Ok(ToolResult::error(format!(
+                    "Command not in allowlist: `{}`",
+                    command
+                )));
+            }
+            Some(argv)
+        };
+
         // Two-step approval gate
         if self.config.require_approval && !approved {
             return Ok(ToolResult::success(serde_json::json!(format!(
@@ -110,24 +218,21 @@ impl Tool for ShellTool {
             ))));
         }
 
-        // Allowed-command prefix check
-        if !self.config.allowed_commands.is_empty() {
-            let allowed = self
-                .config
-                .allowed_commands
-                .iter()
-                .any(|prefix| command.starts_with(prefix.as_str()));
-            if !allowed {
-                return Ok(ToolResult::error(format!(
-                    "Command not in allowlist: `{}`",
-                    command
-                )));
+        // Build the subprocess. An allowlisted command is exec'd directly so
+        // the shell never gets a chance to reinterpret it; without an allowlist
+        // the caller has opted into full shell semantics via `sh -c`.
+        let mut cmd = match argv {
+            Some(argv) => {
+                let mut cmd = Command::new(&argv[0]);
+                cmd.args(&argv[1..]);
+                cmd
             }
-        }
-
-        // Build the subprocess
-        let mut cmd = Command::new("sh");
-        cmd.arg("-c").arg(&command);
+            None => {
+                let mut cmd = Command::new("sh");
+                cmd.arg("-c").arg(&command);
+                cmd
+            }
+        };
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
 
@@ -144,10 +249,7 @@ impl Tool for ShellTool {
                 "Command timed out after {}s: `{}`",
                 timeout_secs, command
             ))),
-            Ok(Err(e)) => Ok(ToolResult::error(format!(
-                "Failed to spawn command: {}",
-                e
-            ))),
+            Ok(Err(e)) => Ok(ToolResult::error(format!("Failed to spawn command: {}", e))),
             Ok(Ok(output)) => {
                 let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
                 let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
@@ -194,7 +296,11 @@ mod tests {
         params.insert("command".to_string(), serde_json::json!("echo hello"));
         let result = tool.execute(params).await.unwrap();
         // Without approved=true, should return pending message
-        assert!(result.output.as_str().unwrap_or("").contains("Pending approval"));
+        assert!(result
+            .output
+            .as_str()
+            .unwrap_or("")
+            .contains("Pending approval"));
     }
 
     #[tokio::test]
@@ -207,5 +313,143 @@ mod tests {
         params.insert("command".to_string(), serde_json::json!("echo hello"));
         let result = tool.execute(params).await.unwrap();
         assert!(result.output.as_str().unwrap_or("").contains("hello"));
+    }
+
+    // ── Allowlist enforcement ─────────────────────────────────────────────────
+
+    /// Run `command` against a tool allowing exactly `allowed`, no approval gate.
+    async fn run_allowlisted(allowed: &[&str], command: &str) -> ToolResult {
+        let tool = ShellTool::new(ShellToolConfig {
+            require_approval: false,
+            allowed_commands: allowed.iter().map(|s| s.to_string()).collect(),
+        });
+        let mut params = HashMap::new();
+        params.insert("command".to_string(), serde_json::json!(command));
+        tool.execute(params).await.unwrap()
+    }
+
+    #[test]
+    fn test_tokenize_splits_on_whitespace() {
+        assert_eq!(tokenize("git status").unwrap(), vec!["git", "status"]);
+        assert_eq!(tokenize("  ls   -la  ").unwrap(), vec!["ls", "-la"]);
+    }
+
+    #[test]
+    fn test_tokenize_honours_quotes() {
+        assert_eq!(
+            tokenize("git commit -m 'two words'").unwrap(),
+            vec!["git", "commit", "-m", "two words"]
+        );
+        // An empty quoted string is still an argument.
+        assert_eq!(tokenize("echo ''").unwrap(), vec!["echo", ""]);
+    }
+
+    #[test]
+    fn test_tokenize_rejects_unterminated_quote() {
+        assert!(tokenize("echo 'unclosed").is_err());
+    }
+
+    #[test]
+    fn test_is_allowed_matches_token_wise() {
+        let allow = vec!["git".to_string()];
+        assert!(is_allowed(&tokenize("git status").unwrap(), &allow));
+        // Prefix matching would have accepted this; token matching must not.
+        assert!(!is_allowed(&tokenize("gitleaks detect").unwrap(), &allow));
+    }
+
+    #[test]
+    fn test_is_allowed_multi_token_entry_constrains_subcommand() {
+        let allow = vec!["git status".to_string()];
+        assert!(is_allowed(&tokenize("git status --short").unwrap(), &allow));
+        assert!(!is_allowed(&tokenize("git push").unwrap(), &allow));
+    }
+
+    /// Regression test for the prefix-matching flaw: an allowlist entry of
+    /// `git` previously permitted `git status; rm -rf ~` because the whole
+    /// string was handed to `sh -c` after a `starts_with` check.
+    #[tokio::test]
+    async fn test_allowlist_rejects_chained_command() {
+        let result = run_allowlisted(&["git"], "git status; echo pwned").await;
+        assert!(!result.success, "chained command must be rejected");
+        let msg = result.error.as_deref().unwrap_or("");
+        assert!(
+            msg.contains("metacharacter"),
+            "expected metacharacter rejection, got: {}",
+            msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_allowlist_rejects_pipe_and_substitution() {
+        for command in [
+            "echo hi | tee /tmp/x",
+            "echo $(whoami)",
+            "echo `whoami`",
+            "echo hi > /tmp/x",
+            "echo a && echo b",
+        ] {
+            let result = run_allowlisted(&["echo"], command).await;
+            assert!(!result.success, "must reject: {}", command);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_allowlist_rejects_non_allowlisted_program() {
+        let result = run_allowlisted(&["echo"], "whoami").await;
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("not in allowlist"));
+    }
+
+    #[tokio::test]
+    async fn test_allowlist_permits_plain_invocation() {
+        let result = run_allowlisted(&["echo"], "echo hello").await;
+        assert!(result.success, "got: {:?}", result.error);
+        assert!(result.output.as_str().unwrap_or("").contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn test_allowlisted_args_are_not_shell_interpreted() {
+        // Exec'd directly, so the metacharacter-free `*` stays literal rather
+        // than being glob-expanded by a shell.
+        let result = run_allowlisted(&["echo"], "echo a*b").await;
+        assert!(result.success);
+        assert!(result.output.as_str().unwrap_or("").contains("a*b"));
+    }
+
+    #[tokio::test]
+    async fn test_empty_allowlist_still_allows_shell_features() {
+        // No allowlist = caller opted into full `sh -c` semantics.
+        let tool = ShellTool::new(ShellToolConfig {
+            require_approval: false,
+            allowed_commands: vec![],
+        });
+        let mut params = HashMap::new();
+        params.insert("command".to_string(), serde_json::json!("echo a && echo b"));
+        let result = tool.execute(params).await.unwrap();
+        assert!(result.success);
+        let out = result.output.as_str().unwrap_or("");
+        assert!(out.contains('a') && out.contains('b'), "got: {}", out);
+    }
+
+    #[tokio::test]
+    async fn test_allowlist_rejection_precedes_approval_gate() {
+        // A command that can never run should be rejected, not queued.
+        let tool = ShellTool::new(ShellToolConfig {
+            require_approval: true,
+            allowed_commands: vec!["echo".to_string()],
+        });
+        let mut params = HashMap::new();
+        params.insert("command".to_string(), serde_json::json!("rm -rf /"));
+        let result = tool.execute(params).await.unwrap();
+        assert!(!result.success);
+        assert!(!result
+            .output
+            .as_str()
+            .unwrap_or("")
+            .contains("Pending approval"));
     }
 }

--- a/src/tools/web_fetch.rs
+++ b/src/tools/web_fetch.rs
@@ -150,10 +150,7 @@ fn strip_html(html: &str) -> String {
 
     // Join with spaces and collapse runs of whitespace
     let joined = parts.join(" ");
-    joined
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
+    joined.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 #[cfg(test)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,8 +1,15 @@
+//! Shared test helpers.
+//!
+//! Cargo compiles this module separately into every integration test binary
+//! that declares `mod common;`. No single binary uses every helper, so unused
+//! items here are expected rather than dead — hence the crate-wide allow.
+#![allow(dead_code)]
+
 use anyhow::Result;
 use async_trait::async_trait;
 use rustynail::agents::AgentManager;
 use rustynail::channels::Channel;
-use rustynail::config::{AgentsConfig, AuditConfig, ChannelsConfig, Config, CronConfig, DeduplicationConfig, GatewayConfig, MemoryConfig, RateLimitConfig, SkillsConfig};
+use rustynail::config::{AgentsConfig, RateLimitConfig, SkillsConfig};
 use rustynail::gateway::dashboard::MessageStats;
 use rustynail::gateway::http::AppState;
 use rustynail::gateway::rate_limiter::RateLimiter;
@@ -40,6 +47,7 @@ pub fn make_test_state_stub() -> AppState {
         dashboard_expected_auth: None,
         api_token: None,
         test_channel: None,
+        test_tx: None,
         rate_limiter: RateLimiter::new(),
         audit: None,
         hot_config: Arc::new(RwLock::new(HotConfig {
@@ -52,59 +60,6 @@ pub fn make_test_state_stub() -> AppState {
         skills_config: SkillsConfig::default(),
         cron_jobs: Vec::new(),
         allowed_ws_origins: Vec::new(),
-    }
-}
-
-/// Minimal test config — no real channels, dummy api_key.
-pub fn make_test_config() -> Config {
-    Config {
-        gateway: GatewayConfig {
-            websocket_port: 18789,
-            http_port: 18081,
-            log_level: "error".to_string(),
-            api_token: None,
-            rate_limit: RateLimitConfig::default(),
-            max_body_bytes: 1_048_576,
-            request_timeout_seconds: 30,
-            allowed_ws_origins: Vec::new(),
-            shutdown_timeout_seconds: 30,
-            chunking_enabled: false,
-            chunking_limits: std::collections::HashMap::new(),
-            formatting_enabled: false,
-            auto_route_attachments: false,
-            deduplication: DeduplicationConfig::default(),
-        },
-        channels: ChannelsConfig {
-            discord: None,
-            whatsapp: None,
-            telegram: None,
-            slack: None,
-            sms: None,
-            webhook: None,
-            webchat: None,
-            email: None,
-            teams: None,
-            test_channel: false,
-        },
-        agents: AgentsConfig {
-            api_key: "test_key_unused".to_string(),
-            ..Default::default()
-        },
-        tools: Default::default(),
-        otel: Default::default(),
-        dashboard: Default::default(),
-        memory: MemoryConfig {
-            vector_decay_half_life_seconds: 3600.0,
-            summarization: rustynail::config::SummarizationConfig {
-                trigger_token_budget: 0,
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        mcp: Default::default(),
-        skills: SkillsConfig::default(),
-        audit: AuditConfig::default(),
-        cron: CronConfig::default(),
     }
 }
 
@@ -142,6 +97,7 @@ pub fn make_test_state() -> AppState {
         dashboard_expected_auth: None,
         api_token: None,
         test_channel: None,
+        test_tx: None,
         rate_limiter: RateLimiter::new(),
         audit: None,
         hot_config: default_hot_config(),
@@ -183,6 +139,7 @@ pub fn make_test_state_with_webhooks() -> (
         dashboard_expected_auth: None,
         api_token: None,
         test_channel: None,
+        test_tx: None,
         rate_limiter: RateLimiter::new(),
         audit: None,
         hot_config: default_hot_config(),

--- a/tests/dashboard.rs
+++ b/tests/dashboard.rs
@@ -4,9 +4,6 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use base64::Engine;
 use rustynail::gateway::http::{create_router, AppState};
-use rustynail::gateway::rate_limiter::RateLimiter;
-use rustynail::gateway::HotConfig;
-use rustynail::config::RateLimitConfig;
 use tower::ServiceExt;
 
 fn make_state_with_auth(password: &str) -> AppState {

--- a/tests/harness/harness_test.rs
+++ b/tests/harness/harness_test.rs
@@ -5,9 +5,52 @@
 //!
 //! Set HARNESS_URL=http://localhost:8080 to enable these tests.
 //! Tests are skipped when HARNESS_URL is not set.
+//!
+//! `GET /test/responses` drains a single process-wide buffer, so these tests
+//! serialize on `HARNESS_LOCK` and drain any stale responses before injecting.
+//! Without that they steal each other's replies when run in parallel.
+
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+/// Async-aware so the guard can be held across the `await`s below.
+static HARNESS_LOCK: Mutex<()> = Mutex::const_new(());
 
 fn harness_url() -> Option<String> {
     std::env::var("HARNESS_URL").ok()
+}
+
+/// Drain and discard anything left in the response buffer by a previous test.
+async fn drain_stale(client: &reqwest::Client, base: &str) {
+    let _ = client.get(format!("{}/test/responses", base)).send().await;
+}
+
+/// Poll `/test/responses` until at least `want` messages arrive, or time out.
+async fn collect_responses(
+    client: &reqwest::Client,
+    base: &str,
+    want: usize,
+) -> Vec<serde_json::Value> {
+    let mut collected = Vec::new();
+    for _ in 0..50 {
+        let body: serde_json::Value = client
+            .get(format!("{}/test/responses", base))
+            .send()
+            .await
+            .expect("responses request failed")
+            .json()
+            .await
+            .expect("parse json");
+
+        if let Some(arr) = body.as_array() {
+            collected.extend(arr.iter().cloned());
+        }
+        if collected.len() >= want {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    collected
 }
 
 #[tokio::test]
@@ -32,8 +75,10 @@ async fn harness_echo() {
         Some(u) => u,
         None => return,
     };
+    let _guard = HARNESS_LOCK.lock().await;
 
     let client = reqwest::Client::new();
+    drain_stale(&client, &base).await;
 
     // Inject a message via POST /test/send
     let send_resp = client
@@ -47,26 +92,21 @@ async fn harness_echo() {
         .expect("send request failed");
     assert_eq!(send_resp.status(), 200);
 
-    // Give the async pipeline a moment to process
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-    // Retrieve responses
-    let responses_resp = client
-        .get(format!("{}/test/responses", base))
-        .send()
-        .await
-        .expect("responses request failed");
-    assert_eq!(responses_resp.status(), 200);
-
-    let responses: serde_json::Value = responses_resp.json().await.expect("parse json");
-    let arr = responses.as_array().expect("expected array");
+    let arr = collect_responses(&client, &base, 1).await;
     assert!(!arr.is_empty(), "expected at least one response");
 
-    // Stub agent in echo mode returns "echo: hello"
+    // The stub agent echoes the whole conversation the ConversationalAgent hands
+    // it (system prompt + history), so assert on the parts we control rather
+    // than an exact "echo: hello".
     let content = arr[0]["content"].as_str().unwrap_or("");
     assert!(
-        content.contains("echo: hello"),
-        "expected echo response, got: {}",
+        content.starts_with("echo:"),
+        "expected stub echo response, got: {}",
+        content
+    );
+    assert!(
+        content.contains("hello"),
+        "expected injected message in response, got: {}",
         content
     );
 }
@@ -77,8 +117,10 @@ async fn harness_multi() {
         Some(u) => u,
         None => return,
     };
+    let _guard = HARNESS_LOCK.lock().await;
 
     let client = reqwest::Client::new();
+    drain_stale(&client, &base).await;
 
     // Send two messages from different users
     for (user, msg) in [("user-a", "first"), ("user-b", "second")] {
@@ -91,17 +133,6 @@ async fn harness_multi() {
         assert_eq!(resp.status(), 200, "send failed for {}", user);
     }
 
-    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
-
-    let responses: serde_json::Value = client
-        .get(format!("{}/test/responses", base))
-        .send()
-        .await
-        .expect("responses failed")
-        .json()
-        .await
-        .expect("parse");
-
-    let arr = responses.as_array().expect("array");
+    let arr = collect_responses(&client, &base, 2).await;
     assert!(arr.len() >= 2, "expected 2 responses, got {}", arr.len());
 }

--- a/tests/message_flow.rs
+++ b/tests/message_flow.rs
@@ -6,7 +6,6 @@ use rustynail::config::AgentsConfig;
 use rustynail::gateway::dashboard::MessageStats;
 use rustynail::gateway::user_prefs::UserPreferences;
 use rustynail::types::Message;
-use rustynail::Gateway;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -1,12 +1,11 @@
 mod common;
 
 use rustynail::agents::AgentManager;
-use rustynail::config::{AgentsConfig, RateLimitConfig};
+use rustynail::config::AgentsConfig;
 use rustynail::gateway::chunker::MessageChunker;
-use rustynail::gateway::deduplicator::MessageDeduplicator;
 use rustynail::gateway::dashboard::MessageStats;
+use rustynail::gateway::deduplicator::MessageDeduplicator;
 use rustynail::gateway::handle_message_for_test_full;
-use rustynail::gateway::rate_limiter::RateLimiter;
 use rustynail::gateway::user_prefs::UserPreferences;
 use rustynail::memory::{InMemoryStore, MemoryStore};
 use rustynail::types::Message;
@@ -61,18 +60,34 @@ async fn test_pipeline_dedup_drops_duplicate() {
 
     // First message — should go through
     handle_message_for_test_full(
-        &mem, &agent_mgr, &channels, &up, &s,
+        &mem,
+        &agent_mgr,
+        &channels,
+        &up,
+        &s,
         msg("alice", "chan1", "hello"),
-        None, None, None, None, false,
+        None,
+        None,
+        None,
+        None,
+        false,
     )
     .await
     .unwrap();
 
     // Exact same message — should be dropped by deduplicator
     handle_message_for_test_full(
-        &mem, &agent_mgr, &channels, &up, &s,
+        &mem,
+        &agent_mgr,
+        &channels,
+        &up,
+        &s,
         msg("alice", "chan1", "hello"),
-        None, None, Some(dedup.clone()), None, false,
+        None,
+        None,
+        Some(dedup.clone()),
+        None,
+        false,
     )
     .await
     .unwrap();
@@ -83,9 +98,17 @@ async fn test_pipeline_dedup_drops_duplicate() {
     let dedup2 = Arc::new(Mutex::new(MessageDeduplicator::new(256)));
 
     handle_message_for_test_full(
-        &mem, &agent_mgr, &channels, &up, &s,
+        &mem,
+        &agent_mgr,
+        &channels,
+        &up,
+        &s,
         msg("bob", "chan1", "unique"),
-        None, None, Some(dedup2.clone()), None, false,
+        None,
+        None,
+        Some(dedup2.clone()),
+        None,
+        false,
     )
     .await
     .unwrap();
@@ -93,9 +116,17 @@ async fn test_pipeline_dedup_drops_duplicate() {
     let before = sent.lock().await.len();
 
     handle_message_for_test_full(
-        &mem, &agent_mgr, &channels, &up, &s,
+        &mem,
+        &agent_mgr,
+        &channels,
+        &up,
+        &s,
         msg("bob", "chan1", "unique"),
-        None, None, Some(dedup2.clone()), None, false,
+        None,
+        None,
+        Some(dedup2.clone()),
+        None,
+        false,
     )
     .await
     .unwrap();
@@ -113,10 +144,7 @@ async fn test_pipeline_multi_user_isolation() {
     let sent_b = chan_b.sent_handle();
 
     let channels: Arc<RwLock<Vec<Box<dyn rustynail::channels::Channel>>>> =
-        Arc::new(RwLock::new(vec![
-            Box::new(chan_a),
-            Box::new(chan_b),
-        ]));
+        Arc::new(RwLock::new(vec![Box::new(chan_a), Box::new(chan_b)]));
 
     let agent_mgr = stub_agent_manager();
     let mem = memory();
@@ -125,18 +153,34 @@ async fn test_pipeline_multi_user_isolation() {
 
     // User A sends a message to chan-a
     handle_message_for_test_full(
-        &mem, &agent_mgr, &channels, &up, &s,
+        &mem,
+        &agent_mgr,
+        &channels,
+        &up,
+        &s,
         msg("userA", "chan-a", "ping from A"),
-        None, None, None, None, false,
+        None,
+        None,
+        None,
+        None,
+        false,
     )
     .await
     .unwrap();
 
     // User B sends a message to chan-b
     handle_message_for_test_full(
-        &mem, &agent_mgr, &channels, &up, &s,
+        &mem,
+        &agent_mgr,
+        &channels,
+        &up,
+        &s,
         msg("userB", "chan-b", "ping from B"),
-        None, None, None, None, false,
+        None,
+        None,
+        None,
+        None,
+        false,
     )
     .await
     .unwrap();
@@ -172,9 +216,17 @@ async fn test_pipeline_chunking_splits_long_response() {
     let up = user_prefs();
 
     handle_message_for_test_full(
-        &mem, &agent_mgr, &channels, &up, &s,
+        &mem,
+        &agent_mgr,
+        &channels,
+        &up,
+        &s,
         msg("user1", "discord-main", &long_input),
-        None, None, None, Some(chunker), false,
+        None,
+        None,
+        None,
+        Some(chunker),
+        false,
     )
     .await
     .unwrap();
@@ -219,9 +271,17 @@ async fn test_pipeline_formatting_slack_applied() {
     let up = user_prefs();
 
     handle_message_for_test_full(
-        &mem, &agent_mgr, &channels, &up, &s,
+        &mem,
+        &agent_mgr,
+        &channels,
+        &up,
+        &s,
         msg("user1", "slack-main", "**hello**"),
-        None, None, None, None, true, // formatting_enabled = true
+        None,
+        None,
+        None,
+        None,
+        true, // formatting_enabled = true
     )
     .await
     .unwrap();


### PR DESCRIPTION
Reconciles a set of defects that had accumulated behind a red CI gate, and releases them as 0.15.0.

## Why CI never caught any of this

Every run since v0.9.0 failed at step 6, `cargo fmt --check`. Because that step precedes them, `cargo clippy -- -D warnings` and `cargo test` never executed upstream — twelve releases shipped without either gate running. Formatting is now clean and every clippy finding is fixed rather than allowed, so the gate does real work again.

## Changes

**Security — shell allowlist (#90).** The allowlist checked `command.starts_with(prefix)` and then handed the whole string to `sh -c`, so an entry of `git` also permitted `git status; rm -rf ~`. Matching is now token-wise against parsed argv, and an allowlisted command is exec'd directly rather than through a shell — the direct exec is the part that actually closes it, since token matching alone still leaves the shell free to reinterpret the string. Rejection also moved ahead of the approval gate.

**Docker builds (#91 tracks the gap).** The builder image was `rust:1.75` while locked dependencies required newer toolchains — `aws-credential-types` 1.3.0 needs 1.94.1. Every Docker release since those crates entered the graph failed. `docker.yml` only runs on tag push, so the failure surfaced after each release was already cut.

**Test harness (#92 tracks the shared buffer).** `POST /test/send` returned a bare 200 without doing anything. Three causes: the handler never enqueued, the gateway built three `TestChannel`s with separate buffers so HTTP watched one nothing wrote to, and the test file had no `[[test]]` target so it was never compiled.

**agenkit pinned to v0.87.0.** A path dependency carries no version constraint, so an upstream push silently changed what CI validated and what release images were built from.

## 0.14.0 reconciliation (#94)

v0.14.0 was recorded as released — CHANGELOG block, closed milestone — but never tagged, and no image was published. It could not have been tagged successfully at the time, since the Docker build was broken. Rather than backdate a tag onto a commit whose image build would fail, that work folds into 0.15.0. The 0.14.0 heading stays with a note, since rewriting it would lose the record.

0.15.0 rather than a patch because the allowlist change is breaking for deployments that configured one.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all exit 0
- 169 tests pass, up from 157 (12 new allowlist tests, incl. a regression test for the `git status; rm -rf ~` vector)
- Docker image builds; `docker run rustynail:v0150 version` prints `rustynail 0.15.0`
- Harness verified round-tripping against a live instance and inside the container

Closes #90
Closes #94