### PR TITLE
ci: enforce release consistency and build at declared MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,62 @@ jobs:
         run: cargo test
         env:
           ANTHROPIC_API_KEY: test_unused
+
+      # Catches version drift between Cargo.toml, Cargo.lock, CHANGELOG,
+      # README, CLAUDE.md and the Helm chart, plus MSRV/Dockerfile and agenkit
+      # pin mismatches. Release-only checks (tag, GitHub release, milestone)
+      # run in the release-consistency workflow, which has network access.
+      - name: Release consistency
+        working-directory: rustynail
+        run: ./scripts/check-release-consistency.sh
+
+  # The Dockerfile builder image MSRV drifted below what the lockfile required
+  # and no tag produced a usable image from v0.9.0 to v0.14.0. `stable` in the
+  # job above cannot catch that; this job builds at the declared MSRV.
+  msrv:
+    name: build at MSRV
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout rustynail
+        uses: actions/checkout@v4
+        with:
+          path: rustynail
+
+      - name: Checkout agenkit (sibling)
+        uses: actions/checkout@v4
+        with:
+          repository: scttfrdmn/agenkit
+          ref: v0.87.0
+          path: agenkit
+
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        working-directory: rustynail
+        run: |
+          v="$(grep -m1 '^rust-version = ' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')"
+          if [ -z "$v" ]; then
+            echo "Cargo.toml has no rust-version field" >&2
+            exit 1
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Install Rust ${{ steps.msrv.outputs.version }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rustynail/target
+          key: ${{ runner.os }}-msrv-${{ steps.msrv.outputs.version }}-${{ hashFiles('rustynail/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-msrv-
+
+      - name: cargo check at MSRV
+        working-directory: rustynail
+        run: cargo check --locked --all-targets

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,18 @@ on:
   push:
     tags:
       - "v*"
+  # Validate the image build before tagging, not after. Every tag from v0.9.0
+  # to v0.14.0 produced a broken image and nobody knew, because this workflow
+  # only ever ran once the release was already cut.
+  pull_request:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "Dockerfile.dockerignore"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/docker.yml"
 
 env:
   REGISTRY: ghcr.io
@@ -15,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # `permissions` cannot take expressions, so this is static. Only tag
+      # builds actually publish — the login and push steps below are gated on
+      # the event being a tag push.
       packages: write
 
     steps:
@@ -33,6 +48,7 @@ jobs:
           path: agenkit
 
       - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -48,6 +64,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
+            # Guarantees a non-empty tag list on pull requests, where the
+            # semver patterns do not match. Never pushed.
+            type=ref,event=pr
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -57,8 +76,26 @@ jobs:
         with:
           context: .
           file: rustynail/Dockerfile
-          push: true
+          # Pull requests build only — they verify the image still compiles
+          # without publishing anything.
+          push: ${{ github.event_name == 'push' }}
+          load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # A successful build is not a working image — v0.9.0 through v0.14.0
+      # taught that the job exit code says nothing about the artifact.
+      - name: Smoke test the built image
+        if: github.event_name == 'pull_request'
+        run: |
+          tag="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -1)"
+          echo "Running: $tag version"
+          out="$(docker run --rm "$tag" version)"
+          echo "$out"
+          expected="$(grep -m1 '^version = ' rustynail/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')"
+          if ! printf '%s\n' "$out" | grep -q "rustynail $expected"; then
+            echo "image did not report version $expected" >&2
+            exit 1
+          fi

--- a/.github/workflows/release-consistency.yml
+++ b/.github/workflows/release-consistency.yml
@@ -1,0 +1,42 @@
+# Verifies that a pushed tag actually corresponds to a coherent release.
+#
+# v0.14.0 was version-bumped and changelogged but never tagged (#94), and
+# v0.5.0/v0.6.0/v0.7.0 were tagged with no GitHub release for four months.
+# Nothing checked, so nothing noticed. This runs on every v* tag and fails
+# loudly when the artifacts disagree.
+#
+# It runs alongside docker.yml rather than gating it: the image build is
+# already in flight by the time a tag lands, so the point here is a visible
+# red X on the release, not prevention after the fact. Run
+# `scripts/check-release-consistency.sh --release` locally before tagging to
+# catch problems while they are still cheap to fix.
+name: Release consistency
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: verify tag, release, milestone
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history plus tags so the ancestor check against main works.
+          fetch-depth: 0
+
+      - name: Fetch main
+        run: git fetch origin main:refs/remotes/origin/main
+
+      - name: Check release consistency
+        run: ./scripts/check-release-consistency.sh --release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `scripts/check-release-consistency.sh` — release consistency gate. Verifies the version in `Cargo.toml` agrees with `Cargo.lock`, `CHANGELOG.md`, `README.md`, `CLAUDE.md` and the Helm chart (`version` and `appVersion`); that the CHANGELOG uses only the six Keep a Changelog headers and has a comparison link; that the Dockerfile builder image matches the declared MSRV; and that both workflows pin agenkit to the same release tag rather than a branch. With `--release` it additionally requires that the tag exists and is an ancestor of `origin/main`, that a GitHub release exists, that no `v*` tag lacks a release, and that the milestone exists and is closed with no open issues. Verified against each historical failure it is meant to catch.
+- `msrv` CI job — builds with `cargo check --locked --all-targets` at the `rust-version` declared in `Cargo.toml` instead of `stable`. Closes #91. Every tag from v0.9.0 to v0.14.0 produced an unusable image because the builder MSRV was below what the lockfile required; `stable` in CI could not detect that, so only tag-time Docker builds failed and those logs went unread.
+- `.github/workflows/release-consistency.yml` — runs the gate in `--release` mode on every `v*` tag, so tag/release/milestone drift surfaces as a failed check instead of going unnoticed for months.
+- `Release consistency` step in the main CI job, gating version coherence on every push and pull request.
+- `docker.yml` now also runs on pull requests touching `Dockerfile`, `Cargo.toml`, `Cargo.lock`, the dockerignore files, or the workflow itself. It builds without publishing (login and push are gated on tag pushes) and smoke-tests the result by running `version` in the built image and asserting it reports the version in `Cargo.toml`. Image builds are validated before a tag is cut rather than after.
+
+### Fixed
+- Backfilled the missing GitHub releases for `v0.5.0`, `v0.6.0` and `v0.7.0`. All three were tagged on 2026-03-18 but never released; they are now published from their original CHANGELOG entries and marked as retroactive.
+- Created the missing `v0.7.0` milestone and closed the `v0.14.0` milestone, which had no open issues but was still marked open.
+
+### Changed
+- `CLAUDE.md` documents a 10-step release checklist and states that a version bump is not a release. Records the three drifts that motivated it: v0.14.0 bumped but never tagged (#94), v0.5.0–v0.7.0 tagged with no release, and the MSRV-broken images from v0.9.0 to v0.14.0. Adds a section on the agenkit path-dependency pin — both workflows must pin the same release tag, never a branch — and notes that the agenkit crate version does not track its repo tags. Also documents that the published image tag has no `v` prefix and is amd64-only.
+
 ## [0.15.0] - 2026-08-03
 
 Includes the documentation work originally logged under `[0.14.0]`, which was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,7 @@ and Docker builds failed on an MSRV too low for the locked dependencies).
 | v0.11.0 | Message Quality & Resilience — chunking, deduplication, channel formatting, attachment routing, retry jitter, provider fallback | Closed (released 2026-03-18) |
 | v0.12.0 | Streaming & Memory Intelligence — Teams HMAC, vector decay, token compaction, WS streaming, OpenAI SSE | Closed (released 2026-03-18) |
 | v0.13.0 | Integration Testing & Operational Maturity — rate limiter/agent/HotConfig/admin API/Teams/pipeline tests, config validate, admin audit logging | Closed (released 2026-03-18) |
-| v0.14.0 | Deployment & User Documentation — README overhaul, docs/ reference directory (configuration, deployment, channels, CLI, API, architecture, troubleshooting) | Never tagged; shipped as part of v0.15.0 (#94) |
+| v0.14.0 | Deployment & User Documentation — README overhaul, docs/ reference directory (configuration, deployment, channels, CLI, API, architecture, troubleshooting) | Milestone closed; never tagged — shipped inside v0.15.0 (#94). No `v0.14.0` tag or release exists, by design |
 | v0.15.0 | Build & Supply Chain Correctness — shell allowlist hardening, working Docker build (MSRV 1.94), functional test harness, green CI, agenkit pinned to v0.87.0 | Closed (released 2026-08-03) |
 | v1.0.0 | Production Ready — full hardening, docs, dashboard v2 | Open |
 | v1.1.0 | Post-1.0 Channel Expansion — Matrix, Signal/IRC/LINE/Viber/WeChat, social DMs | Open |
@@ -360,6 +360,60 @@ Follow [keepachangelog.com](https://keepachangelog.com/en/1.1.0/) strictly:
   - `### Security` — security vulnerability fixes
 - **Never use**: `### Planned`, `### Technical Specifications`, `### Documentation`, or any other custom headers
 - Do NOT list planned future work in `[Unreleased]` — that belongs in GitHub issues
+
+### Releasing — a version is not released until every artifact agrees
+
+A version bump is not a release. Three separate drifts got this far unnoticed
+because each step was manual and nothing verified the result:
+
+- **v0.14.0** had a version bump, a CHANGELOG entry, and a closed milestone —
+  but no tag and no release (#94). The version existed only in files.
+- **v0.5.0, v0.6.0, v0.7.0** were tagged but had no GitHub release for four
+  months, and v0.7.0 had no milestone at all.
+- **Every tag from v0.9.0 to v0.14.0** produced no usable image: the Dockerfile
+  builder MSRV was below what `Cargo.lock` required. CI used `stable`, so only
+  tag builds broke — and nobody read those logs.
+
+**Run the gate before tagging. It is not optional:**
+
+```bash
+scripts/check-release-consistency.sh            # version coherence (also runs in CI)
+scripts/check-release-consistency.sh --release  # + tag, release, milestone
+```
+
+Release checklist — every box, in this order:
+
+1. `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD`; add a fresh empty `[Unreleased]`
+2. Add the `[X.Y.Z]:` comparison link at the bottom and repoint `[Unreleased]`
+3. Bump the version in **all six**: `Cargo.toml`, `Cargo.lock` (via
+   `cargo update -p rustynail`), `README.md`, `CLAUDE.md`, `Chart.yaml`
+   (`version` **and** `appVersion`), and any `docs/*.md` sample output
+4. `scripts/check-release-consistency.sh` — must exit 0
+5. Merge to `main` and **wait for CI to go green on the merge commit**, not just
+   on the PR
+6. `git tag -a vX.Y.Z -m "…"` and `git push origin vX.Y.Z`
+7. `gh release create vX.Y.Z --notes-file …` — a tag alone is not a release
+8. Close the milestone; create it first if it does not exist
+9. `scripts/check-release-consistency.sh --release` — must exit 0
+10. Confirm `docker.yml` succeeded **and pull the image** to verify it runs.
+    Note the published tag has no `v` prefix (`ghcr.io/scttfrdmn/rustynail:X.Y.Z`),
+    and the image is amd64-only — on arm64 pass `--platform linux/amd64`
+
+Never mark a release done on the strength of a green checkmark alone. Job
+success means the step exited 0, not that the artifact works — pull it and run
+it.
+
+### agenkit dependency pin
+
+agenkit is a **path dependency**, so Cargo cannot constrain its version. The
+`ref:` in the workflows is the only pin that exists. Both `ci.yml` and
+`docker.yml` must pin the **same release tag** — never a branch — or an
+upstream push silently changes what CI validates and what the release image
+contains. The consistency gate enforces this.
+
+Note the agenkit crate version does not track its repo tags (the crate reads
+`0.83.0` at tag `v0.87.0`, since tags span a polyglot repo). The tag is the
+only usable pin point.
 
 ### Commit Convention (Conventional Commits)
 

--- a/scripts/check-release-consistency.sh
+++ b/scripts/check-release-consistency.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# Release consistency gate.
+#
+# Every release artifact must agree on one version. Three separate incidents
+# motivated this check:
+#
+#   1. v0.14.0 shipped a CHANGELOG entry and version bump but was never tagged
+#      or released (#94) — the version existed only in files.
+#   2. v0.5.0, v0.6.0 and v0.7.0 were tagged but had no GitHub release, and
+#      v0.7.0 had no milestone at all. Nothing noticed for four months.
+#   3. Docker builds failed at every tag from v0.9.0 onward because the builder
+#      image MSRV was below what the lockfile required, so no tag ever produced
+#      a usable image.
+#
+# All three were invisible because release steps were manual and unverified.
+# This script is the verification. It runs in CI on every push and PR (version
+# coherence only) and in full mode before a release.
+#
+# Usage:
+#   scripts/check-release-consistency.sh            # local/CI: files must agree
+#   scripts/check-release-consistency.sh --release  # also require tag/release/milestone
+#
+# Exit 0 = consistent, 1 = drift found.
+
+set -uo pipefail
+
+RELEASE_MODE=0
+[[ "${1:-}" == "--release" ]] && RELEASE_MODE=1
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+FAILED=0
+pass() { printf '[\xe2\x9c\x93] %s\n' "$1"; }
+fail() { printf '[\xe2\x9c\x97] %s\n' "$1"; FAILED=1; }
+
+# ── Source of truth ───────────────────────────────────────────────────────────
+
+VERSION="$(grep -m1 '^version = ' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')"
+if [[ -z "$VERSION" ]]; then
+  fail "could not read version from Cargo.toml"
+  exit 1
+fi
+echo "Cargo.toml version: $VERSION"
+echo
+
+# ── 1. Version coherence across files ─────────────────────────────────────────
+# Each of these carried a stale version at some point in this repo's history.
+
+check_contains() {
+  local file="$1" pattern="$2" label="$3"
+  if [[ ! -f "$file" ]]; then
+    fail "$label: $file not found"
+    return
+  fi
+  if grep -q "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label: $file does not mention $VERSION"
+  fi
+}
+
+check_contains "CHANGELOG.md" "^## \[$VERSION\]" "CHANGELOG has a [$VERSION] section"
+check_contains "README.md" "$VERSION" "README references $VERSION"
+check_contains "CLAUDE.md" "\*\*Version\*\*: $VERSION" "CLAUDE.md Version field is $VERSION"
+
+# Cargo.lock must record the same version for this package, or a release build
+# resolves something other than what Cargo.toml claims.
+if grep -A1 '^name = "rustynail"$' Cargo.lock | grep -q "version = \"$VERSION\""; then
+  pass "Cargo.lock rustynail entry is $VERSION"
+else
+  fail "Cargo.lock rustynail entry is not $VERSION (run: cargo update -p rustynail)"
+fi
+
+CHART="deploy/helm/rustynail/Chart.yaml"
+if [[ -f "$CHART" ]]; then
+  chart_ver="$(grep -m1 '^version:' "$CHART" | awk '{print $2}')"
+  chart_app="$(grep -m1 '^appVersion:' "$CHART" | tr -d '"' | awk '{print $2}')"
+  if [[ "$chart_ver" == "$VERSION" ]]; then
+    pass "Helm chart version is $VERSION"
+  else
+    fail "Helm chart version is $chart_ver, expected $VERSION"
+  fi
+  if [[ "$chart_app" == "$VERSION" ]]; then
+    pass "Helm chart appVersion is $VERSION"
+  else
+    fail "Helm chart appVersion is $chart_app, expected $VERSION"
+  fi
+fi
+
+# ── 2. Changelog hygiene (Keep a Changelog 1.1.0) ─────────────────────────────
+
+if grep -q '^## \[Unreleased\]' CHANGELOG.md; then
+  pass "CHANGELOG has an [Unreleased] section"
+else
+  fail "CHANGELOG is missing the [Unreleased] section"
+fi
+
+# Only the six Keep a Changelog headers are permitted. CLAUDE.md forbids
+# invented headers such as "### Planned" or "### Documentation".
+bad_headers="$(grep '^### ' CHANGELOG.md \
+  | grep -vE '^### (Added|Changed|Deprecated|Removed|Fixed|Security)$' \
+  | sort -u)"
+if [[ -z "$bad_headers" ]]; then
+  pass "CHANGELOG uses only the six Keep a Changelog headers"
+else
+  fail "CHANGELOG has non-standard headers:"
+  printf '      %s\n' "$bad_headers"
+fi
+
+# The comparison link for the current version must exist, or the changelog
+# footer silently rots as versions accumulate.
+if grep -q "^\[$VERSION\]:" CHANGELOG.md; then
+  pass "CHANGELOG has a comparison link for $VERSION"
+else
+  fail "CHANGELOG has no [$VERSION]: comparison link at the bottom"
+fi
+
+# ── 3. MSRV / Dockerfile agreement ────────────────────────────────────────────
+# Incident 3: Dockerfile builder was rust:1.75 while dependencies needed 1.94.
+# CI used `stable` so it never noticed; only tag builds broke.
+
+MSRV="$(grep -m1 '^rust-version = ' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')"
+if [[ -z "$MSRV" ]]; then
+  fail "Cargo.toml has no rust-version (MSRV) field"
+else
+  pass "Cargo.toml declares MSRV $MSRV"
+  if [[ -f Dockerfile ]]; then
+    docker_rust="$(grep -m1 -oE 'rust:[0-9]+\.[0-9]+(\.[0-9]+)?' Dockerfile | cut -d: -f2)"
+    if [[ -z "$docker_rust" ]]; then
+      fail "could not determine builder Rust version from Dockerfile"
+    elif [[ "$docker_rust" == "$MSRV"* || "$MSRV" == "$docker_rust"* ]]; then
+      pass "Dockerfile builder Rust $docker_rust matches MSRV $MSRV"
+    else
+      fail "Dockerfile builder Rust is $docker_rust but MSRV is $MSRV"
+    fi
+  fi
+fi
+
+# ── 4. agenkit pin agreement ──────────────────────────────────────────────────
+# agenkit is a path dependency, so Cargo cannot constrain its version. The
+# workflow `ref:` is the only pin, and the released image must be built against
+# the same revision CI validated.
+
+ci_ref="$(grep -A6 'repository: scttfrdmn/agenkit' .github/workflows/ci.yml | grep -m1 'ref:' | awk '{print $2}')"
+docker_ref="$(grep -A6 'repository: scttfrdmn/agenkit' .github/workflows/docker.yml | grep -m1 'ref:' | awk '{print $2}')"
+
+if [[ -z "$ci_ref" ]]; then
+  fail "ci.yml does not pin the agenkit checkout to a ref"
+elif [[ "$ci_ref" == "main" || "$ci_ref" == "master" ]]; then
+  fail "ci.yml pins agenkit to '$ci_ref' — pin a release tag, not a branch"
+else
+  pass "ci.yml pins agenkit to $ci_ref"
+fi
+
+if [[ "$ci_ref" == "$docker_ref" ]]; then
+  pass "docker.yml agenkit pin matches ci.yml ($docker_ref)"
+else
+  fail "agenkit pin drift: ci.yml=$ci_ref docker.yml=$docker_ref"
+fi
+
+# ── 5. Release-only checks ────────────────────────────────────────────────────
+# Incidents 1 and 2. Requires `gh` and network access, so it is gated behind
+# --release rather than running on every PR.
+
+if [[ "$RELEASE_MODE" == "1" ]]; then
+  echo
+  echo "Release checks:"
+
+  if ! command -v gh >/dev/null 2>&1; then
+    fail "gh CLI not available; cannot verify tag/release/milestone"
+  else
+    # A tag must exist for this version and point at a commit on main.
+    if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+      pass "tag v$VERSION exists"
+      if git merge-base --is-ancestor "v$VERSION" origin/main 2>/dev/null; then
+        pass "tag v$VERSION is an ancestor of origin/main"
+      else
+        fail "tag v$VERSION is not on origin/main"
+      fi
+    else
+      fail "tag v$VERSION does not exist (incident #94: version bumped, never tagged)"
+    fi
+
+    # Every tag needs a GitHub release. v0.5.0/v0.6.0/v0.7.0 went four months
+    # without one.
+    if gh release view "v$VERSION" >/dev/null 2>&1; then
+      pass "GitHub release v$VERSION exists"
+    else
+      fail "no GitHub release for v$VERSION"
+    fi
+
+    orphan_tags="$(comm -23 \
+      <(git tag -l 'v*' | sort) \
+      <(gh release list --limit 100 --json tagName -q '.[].tagName' | sort))"
+    if [[ -z "$orphan_tags" ]]; then
+      pass "every v* tag has a corresponding GitHub release"
+    else
+      fail "tags with no GitHub release:"
+      printf '      %s\n' "$orphan_tags"
+    fi
+
+    # A milestone should exist and be closed for a shipped version.
+    ms_state="$(gh api "repos/scttfrdmn/rustynail/milestones?state=all&per_page=100" \
+      --jq ".[] | select(.title | startswith(\"v$VERSION\")) | .state" 2>/dev/null | head -1)"
+    case "$ms_state" in
+      closed) pass "milestone v$VERSION exists and is closed" ;;
+      open)   fail "milestone v$VERSION is still open" ;;
+      *)      fail "no milestone found for v$VERSION" ;;
+    esac
+
+    # A closed milestone with open issues means the release claims work it
+    # did not ship.
+    stragglers="$(gh api "repos/scttfrdmn/rustynail/milestones?state=all&per_page=100" \
+      --jq '.[] | select(.state=="closed" and .open_issues>0) | "\(.title) (\(.open_issues) open)"' 2>/dev/null)"
+    if [[ -z "$stragglers" ]]; then
+      pass "no closed milestone has open issues"
+    else
+      fail "closed milestones with open issues:"
+      printf '      %s\n' "$stragglers"
+    fi
+  fi
+fi
+
+echo
+if [[ "$FAILED" == "0" ]]; then
+  echo "All release consistency checks passed."
+else
+  echo "Release consistency check FAILED — see [x] lines above."
+fi
+exit "$FAILED"


### PR DESCRIPTION
## Why

Three release drifts reached production because every release step was manual and nothing verified the result:

| Incident | What happened |
|---|---|
| **#94** | v0.14.0 was version-bumped and changelogged but never tagged or released — the version existed only in files |
| **orphan tags** | v0.5.0, v0.6.0, v0.7.0 were tagged with no GitHub release for four months; v0.7.0 had no milestone at all |
| **broken images** | Every tag from v0.9.0 to v0.14.0 published an unusable image — the Dockerfile builder MSRV was below what `Cargo.lock` required |

None was caught, because nothing checked. The data drift is already repaired (releases backfilled, milestones reconciled). This PR closes the gap that allowed it.

## What

**`scripts/check-release-consistency.sh`** — the gate.

Default mode (runs in CI on every push and PR):
- version agreement across `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`, `README.md`, `CLAUDE.md`, `Chart.yaml` (`version` **and** `appVersion`)
- Keep a Changelog hygiene — only the six valid headers, `[Unreleased]` present, comparison link present
- `Dockerfile` builder image matches the declared `rust-version`
- both workflows pin agenkit to the **same release tag**, never a branch

`--release` mode adds:
- tag exists and is an ancestor of `origin/main`
- a GitHub release exists for it
- **no** `v*` tag lacks a release
- milestone exists, is closed, and no closed milestone has open issues

**`msrv` CI job** — `cargo check --locked --all-targets` at the `rust-version` from `Cargo.toml` rather than `stable`. Reads the value from the manifest so it cannot drift. Closes #91.

**`docker.yml` on PRs** — builds without publishing (login and push gated on tag pushes) when `Dockerfile`, `Cargo.toml`, `Cargo.lock` or the workflow changes, then smoke-tests the image by running `version` and asserting the reported version. Addresses the follow-on suggestion in #91.

**`release-consistency.yml`** — runs the gate in `--release` mode on every `v*` tag.

**`CLAUDE.md`** — 10-step release checklist, the agenkit pin rule, and the note that the published image tag has no `v` prefix and is amd64-only.

## Verification

A gate that only passes proves nothing, so each check was tested against the failure it exists to catch — reproduced in a scratch worktree:

| Simulated | Result |
|---|---|
| Cargo.toml bumped, nothing else | 6 failures across CHANGELOG/README/CLAUDE.md/lock/chart |
| Full #94 shape (files bumped, never tagged) | `tag v0.16.0 does not exist`, `no GitHub release`, `no milestone` |
| Dockerfile reverted to `rust:1.75` | `builder Rust is 1.75 but MSRV is 1.94` |
| agenkit pin loosened to `main` | `pin a release tag, not a branch` |
| pins drift between workflows | `ci.yml=v0.87.0 docker.yml=v0.88.0` |
| `### Planned` header added | `non-standard headers: ### Planned` |

Also: `shellcheck` clean, all three workflow YAMLs parse, and the smoke-test logic was validated against the real published `ghcr.io/scttfrdmn/rustynail:0.15.0` image.

Closes #91