### PR TITLE
docs: record that the project stays on 0.x.x until further notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Created the missing `v0.7.0` milestone and closed the `v0.14.0` milestone, which had no open issues but was still marked open.
 
 ### Changed
+- Documented that the project stays on `0.x.x` until further notice: `1.0.0` is not a target and the `v1.0.0` milestone is a bucket for API-stability-gated work, not a timeline. `CLAUDE.md` versioning section and milestone table updated; `README.md` states the API and config format may change in any minor release.
 - `CLAUDE.md` documents a 10-step release checklist and states that a version bump is not a release. Records the three drifts that motivated it: v0.14.0 bumped but never tagged (#94), v0.5.0–v0.7.0 tagged with no release, and the MSRV-broken images from v0.9.0 to v0.14.0. Adds a section on the agenkit path-dependency pin — both workflows must pin the same release tag, never a branch — and notes that the agenkit crate version does not track its repo tags. Also documents that the published image tag has no `v` prefix and is amd64-only.
 
 ## [0.15.0] - 2026-08-03

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,8 +238,9 @@ and Docker builds failed on an MSRV too low for the locked dependencies).
 | v0.13.0 | Integration Testing & Operational Maturity — rate limiter/agent/HotConfig/admin API/Teams/pipeline tests, config validate, admin audit logging | Closed (released 2026-03-18) |
 | v0.14.0 | Deployment & User Documentation — README overhaul, docs/ reference directory (configuration, deployment, channels, CLI, API, architecture, troubleshooting) | Milestone closed; never tagged — shipped inside v0.15.0 (#94). No `v0.14.0` tag or release exists, by design |
 | v0.15.0 | Build & Supply Chain Correctness — shell allowlist hardening, working Docker build (MSRV 1.94), functional test harness, green CI, agenkit pinned to v0.87.0 | Closed (released 2026-08-03) |
-| v1.0.0 | Production Ready — full hardening, docs, dashboard v2 | Open |
-| v1.1.0 | Post-1.0 Channel Expansion — Matrix, Signal/IRC/LINE/Viber/WeChat, social DMs | Open |
+| v0.16.0 | Release Process Enforcement & Correctness — pre-tag gating (#97), harness buffer isolation (#92), verify README claims (#93) | Open |
+| v1.0.0 | Deferred — work gated on a stable API. **Not a target**; the project stays on `0.x.x` until further notice | Open |
+| v1.1.0 | Deferred — channel expansion: Matrix, Signal/IRC/LINE/Viber/WeChat, social DMs | Open |
 
 ## Architecture Overview
 
@@ -343,6 +344,13 @@ Follow [semver.org](https://semver.org/spec/v2.0.0.html) strictly:
 - **PATCH** (`0.0.X`): backwards-compatible bug fixes only
 
 Pre-1.0: minor bumps (`0.X.0`) may include breaking changes.
+
+**This project stays on `0.x.x` until further notice.** Do not propose, plan or
+cut a `1.0.0` release, and do not treat the `v1.0.0` milestone as a target date
+— it is a bucket for work that is genuinely gated on a stable API, not a
+timeline. New work belongs in the next `0.x.0` milestone. Breaking changes are
+allowed in a minor bump and must be marked **BREAKING** in the CHANGELOG entry
+(see the shell allowlist change in `[0.15.0]` for the expected form).
 
 ### Changelog (Keep a Changelog 1.1.0)
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,9 @@ Follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html). Pre-1.
 
 Current version: **0.15.0 (Beta)**
 
+RustyNail stays on `0.x.x` until further notice. There is no 1.0 timeline; treat
+the API and configuration format as subject to change in any minor release.
+
 See [CHANGELOG.md](CHANGELOG.md) for the full history.
 
 ## License


### PR DESCRIPTION
Per direction: RustyNail stays on `0.x.x` until further notice.

## Why

The `v1.0.0` milestone had become the default destination for ordinary near-term work — #92 (test harness), #93 (README claims), and briefly #97 (release gating), none of which is gated on API stability. That framed 1.0 as the next release and implied a timeline that does not exist.

## Changes

- **New `v0.16.0` milestone** — #97, #92, #93 moved there. `v1.0.0` now holds only #14 (OpenClaw migration tool), which genuinely is 1.0-scoped.
- **`CLAUDE.md` versioning section** — states 1.0.0 is not to be proposed, planned or cut, and that `v1.0.0` is a bucket for API-stability-gated work rather than a target date. Restates that breaking changes are allowed in a minor bump and must be marked **BREAKING** in the CHANGELOG.
- **`CLAUDE.md` milestone table** — adds the `v0.16.0` row; relabels `v1.0.0` and `v1.1.0` as deferred.
- **`README.md`** — notes the API and configuration format are subject to change in any minor release.

Docs and metadata only; no code or workflow changes. `scripts/check-release-consistency.sh` passes.